### PR TITLE
Changed date formats to 12hr - Fixed installer bug that was calling wron...

### DIFF
--- a/docroot/profiles/ilr/ilr.install
+++ b/docroot/profiles/ilr/ilr.install
@@ -98,8 +98,8 @@ function ilr_install() {
 
   // Explicitly call any hook_update_n implementations needed to run on install.
   // These hooks will be skipped by initial install but will run on updatedb of current site.
-  ilr_update_7006();
   ilr_update_7007();
+  ilr_update_7008();
 
   // Add Migrations here as necessary
 }


### PR DESCRIPTION
Changed date formats to 12hr - Fixed installer bug that was calling wrong hook_update_n implementations.

This sets site wide date formats to include 12hr.
