### PR TITLE
Added ability for course admin to import sdc listings manually

### DIFF
--- a/docroot/profiles/ilr/ilr.install
+++ b/docroot/profiles/ilr/ilr.install
@@ -203,12 +203,13 @@ function ilr_update_7010() {
  * Custom function for role creation
  */
 function _ilr_create_roles() {
-  $roles = array('administrator','contributor','neutral admin', 'neutral', 'registered user', 'wit editor', 'faculty admin');
+  $roles = array('administrator','contributor','neutral admin', 'neutral', 'registered user', 'wit editor', 'faculty admin', 'course admin');
 
+  $weight = 0;
   foreach ($roles as $name) {
     $role = new stdClass();
     $role->name = $name;
-    $role->weight = 2;
+    $role->weight = $weight++;
     user_role_save($role);
   }
 }

--- a/docroot/profiles/ilr/ilr.profile
+++ b/docroot/profiles/ilr/ilr.profile
@@ -374,3 +374,21 @@ function ilr_entity_info_alter(&$entity_info) {
     ),
   );
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter() for feeds_import_form.
+ *
+ * If the user doesn't have "Administer Feeds" permission then remove options to change settings.
+ */
+function ilr_form_feeds_import_form_alter(&$form, &$form_state, $form_id) {
+ $importer = feeds_importer($form['#importer_id']);
+ $form['feeds_description'] = array(
+   '#type' => 'markup',
+   '#markup' => check_plain($importer->config['description']),
+   '#weight' => -100,
+ );
+
+ if (!user_access('administer feeds')) {
+   $form['feeds']['#access'] = FALSE;
+ }
+}

--- a/docroot/sites/all/modules/features/ilr_permissions/ilr_permissions.features.user_permission.inc
+++ b/docroot/sites/all/modules/features/ilr_permissions/ilr_permissions.features.user_permission.inc
@@ -16,6 +16,7 @@ function ilr_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'contributor' => 'contributor',
+      'course admin' => 'course admin',
       'neutral admin' => 'neutral admin',
       'wit editor' => 'wit editor',
     ),
@@ -28,6 +29,7 @@ function ilr_permissions_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'contributor' => 'contributor',
+      'course admin' => 'course admin',
       'neutral admin' => 'neutral admin',
       'wit editor' => 'wit editor',
     ),
@@ -1344,6 +1346,16 @@ function ilr_permissions_user_default_permissions() {
       'administrator' => 'administrator',
     ),
     'module' => 'features',
+  );
+
+  // Exported permission: 'import sdc_course_importer feeds'.
+  $permissions['import sdc_course_importer feeds'] = array(
+    'name' => 'import sdc_course_importer feeds',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'course admin' => 'course admin',
+    ),
+    'module' => 'feeds',
   );
 
   // Exported permission: 'import wysiwyg templates'.

--- a/docroot/sites/all/modules/features/ilr_permissions/ilr_permissions.info
+++ b/docroot/sites/all/modules/features/ilr_permissions/ilr_permissions.info
@@ -169,6 +169,7 @@ features[user_permission][] = edit terms in wire_services
 features[user_permission][] = execute php code
 features[user_permission][] = flush caches
 features[user_permission][] = generate features
+features[user_permission][] = import sdc_course_importer feeds
 features[user_permission][] = import wysiwyg templates
 features[user_permission][] = manage features
 features[user_permission][] = menu view unpublished

--- a/docroot/sites/all/modules/features/ilr_sdc_listings/ilr_sdc_listings.feeds_importer_default.inc
+++ b/docroot/sites/all/modules/features/ilr_sdc_listings/ilr_sdc_listings.feeds_importer_default.inc
@@ -208,7 +208,7 @@ function ilr_sdc_listings_feeds_importer_default() {
   $feeds_importer->id = 'sdc_course_importer';
   $feeds_importer->config = array(
     'name' => 'SDC Course Importer',
-    'description' => 'SDC course json importer',
+    'description' => 'SDC Course importer. This will also trigger class and faculty importers.',
     'fetcher' => array(
       'plugin_key' => 'FeedsHTTPFetcher',
       'config' => array(

--- a/docroot/sites/all/modules/features/ilr_sdc_listings/ilr_sdc_listings.module
+++ b/docroot/sites/all/modules/features/ilr_sdc_listings/ilr_sdc_listings.module
@@ -46,6 +46,8 @@ function ilr_sdc_listings_feeds_after_parse(FeedsSource $source, FeedsParserResu
   $importer_ids = _ilr_sdc_listings_get_importer_ids();
 
   if (in_array($source->importer->id, $importer_ids)) {
+    // These importer might take a longtime.
+    set_time_limit(600);
     foreach ($result->items as &$item) {
       _ilr_sdc_listings_prepare_source_item($item, $source);
     }


### PR DESCRIPTION
There is a new role "course admin" 

Create a user with this role.  
Login as the new user
Goto either /import(list) or import/sdc_faculty_importer(direct)
Run importer

There is php notice that shows up:
"Notice: Undefined index: unique in FeedsJSONPathParser->sourceForm() (line 148 of /var/www/ilr-website/docroot/sites/all/modules/contrib/feeds_jsonpath_parser/FeedsJSONPathParser.inc)."

This known bug in Feeds JSONPath Parser.
This has been committed to project but there is not a new release.

Patch for current version is here: https://www.drupal.org/node/1988094#comment-7762507

Don't know if it worth running patched version of the module to fix this.
I have checked the code and it works fine as is.  Users shouldn't be seeing PHP notices anyways.
