### PR TITLE
Fixes bug in workspan migration

### DIFF
--- a/docroot/sites/all/modules/custom/ilr_migrations/workspan.inc
+++ b/docroot/sites/all/modules/custom/ilr_migrations/workspan.inc
@@ -41,7 +41,7 @@ class WorkspanMigration extends Migration {
     $this->addFieldMapping('field_file', 'article_pdf');
     $this->addFieldMapping('field_file:source_dir')
       ->defaultValue($this->getFileDir() . 'pdfs');
-    $this->addFieldMapping("field_tags")->defaultValue('workspan');
+    $this->addFieldMapping("field_tags")->defaultValue(array());
   }
 
   public function prepareRow($row) {


### PR DESCRIPTION
FYI…

Adding a real tag `workspan` resolved the bug. Not sure why this bug emerged after a previous successful run of the migration. the underlying issue may still exist for other migrations of tagged content types when no mapping for field_tags is provided.
