### PR TITLE
Check for menu by top link alias

### DIFF
--- a/docroot/sites/all/modules/custom/ilr_sub_sites/ilr_sub_sites.module
+++ b/docroot/sites/all/modules/custom/ilr_sub_sites/ilr_sub_sites.module
@@ -330,12 +330,28 @@ function _ilr_sub_sites_get_current_menu_name() {
 
     return strlen($menu_name) ? $menu_name : 'main-menu';
   }
-  elseif ($menu_name = _ilr_sub_sites_check_for_menu_by_name(arg(0))) {
+  elseif ($menu_name = _ilr_sub_sites_check_for_menu_by_top_path(arg(0))) {
     return $menu_name;
   }
   return 'main-menu';
 }
 
+/**
+ * Check if a path is the top link for a subsite menu.
+ *
+ * @todo Are there any other menus to ignore beside main-menu and user-menu
+ * @param $path
+ *
+ * @return bool
+ */
+function _ilr_sub_sites_check_for_menu_by_top_path($path) {
+  $normal_path = drupal_get_normal_path($path);
+  $menu_name = db_query('SELECT menu_name FROM {menu_links} WHERE link_path =:link_path and plid = 0', array(':link_path' => $normal_path))->fetchField();
+  if ($menu_name && $menu_name != 'user-menu' && $menu_name != 'main-menu') {
+    return $menu_name;
+  }
+  return FALSE;
+}
 function _ilr_sub_sites_get_current_node() {
   $node = &drupal_static(__FUNCTION__);
   if (!isset($node)) {

--- a/docroot/sites/all/themes/ilr_theme/js/ilr_theme.js
+++ b/docroot/sites/all/themes/ilr_theme/js/ilr_theme.js
@@ -291,7 +291,8 @@
   Drupal.behaviors.ilr_theme_subsite_wrapper = {
     attach: function (context, settings) {
       $(window).load(function() {
-        if(document.location.href.indexOf("/worker-institute") > -1 && isSubsite()) {
+        // @todo Alter links on server side via hook_url_outbound_alter?
+        if(isSubsite()) {
           $links = $(".tagged-content a, .bean-content-listing-manual a, .view-course-manual-listings a");
           $links.each(function(){
             $href = $(this).attr('href');


### PR DESCRIPTION
This fixes a problem in detecting subsite that relied on menu machine name being the same as the top link alias.

It should allow serving /news and /professional-programs links from:
 [subsite-alias]/news and [subsite-alias]/professional-programs