### PR TITLE
Adds fieldOrderBy to _ilr_sdc_listings_get_classes_for_course to list SD...

### DIFF
--- a/docroot/sites/all/modules/features/ilr_sdc_listings/ilr_sdc_listings.module
+++ b/docroot/sites/all/modules/features/ilr_sdc_listings/ilr_sdc_listings.module
@@ -502,7 +502,8 @@ function _ilr_sdc_listings_get_classes_for_course($course_node, $class_nids = NU
     ->entityCondition('bundle', 'sdc_class')
     ->propertyCondition('status', 1)
     ->fieldCondition('field_course', 'target_id', $course_node->nid)
-    ->fieldCondition('field_registration_end_date', 'value', $today, '>=');
+    ->fieldCondition('field_registration_end_date', 'value', $today, '>=')
+    ->fieldOrderBy('field_class_dates', 'value');
   if ($class_nids) {
     $query->propertyCondition('nid', $class_nids);
   }


### PR DESCRIPTION
...C classes in date order.  Note - The change, which was just one additional line of code in the file ilr_sdc_listings.module, fixes the course pages so classes are now listed in date order. However, I don't know if it messes anything else up.  