### PR TITLE
Adjusts width for sponsor message paragraph bundle

### DIFF
--- a/docroot/sites/all/themes/ilr_theme/scss/components/_pb_sponsor_message.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_pb_sponsor_message.scss
@@ -4,6 +4,9 @@
     @include padding-trailer(1);
     .content {
       @include grid-span (10,2);
+      .centered-blurb {
+        max-width: 960px;
+      }
     }
     h2 {
       text-align: center;


### PR DESCRIPTION
This was a bug fix that does not need to be deployed to featuretest.