### PR TITLE
Hides degree and class year for exp reports when displayed as teaser …

### DIFF
--- a/docroot/sites/all/themes/ilr_theme/scss/components/_featured_profile.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_featured_profile.scss
@@ -186,6 +186,9 @@ body.node-type-experience-report {
         .field-name-field-image {
           background: $promo-color;
         }
+        .field-name-field-year-as-text {
+          display: none;
+        }
       }
     }
   }


### PR DESCRIPTION
…in nav at bottom of an exp report.

Bug fix ready to be merged.