### PR TITLE
Adds update hook to delete transfer_offer submissions

### DIFF
--- a/docroot/sites/all/modules/features/forms/forms.install
+++ b/docroot/sites/all/modules/features/forms/forms.install
@@ -202,6 +202,12 @@ function forms_update_7014() {
 }
 
 /**
+ * Delete subm from Admissions Transfer Option form
+ */
+function forms_update_7015() {
+  _forms_delete_entityform_submissions('transfer_offer');
+}
+/**
 * Delete one or more field instances from one entityform
 * @param $form_id
 * @param $field_names


### PR DESCRIPTION
Tested this locally and on dev, it's just a simple update hook (7015) in forms.install to delete the submissions. I'll also add this to tracker.