### PR TITLE
Switches layout of SLS moderators for odd number of items

### DIFF
--- a/docroot/sites/all/themes/ilr_theme/scss/components/_sls.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_sls.scss
@@ -557,6 +557,11 @@ body.subsite-front {
         background-color: white;
         padding-left: 89px;
         padding-right: 89px;
+        .mod-last-row { //2 articles in last row
+          padding: 21px 212px 0;
+          clear: both;
+          overflow: auto;
+        }
       }
       #block-bean-sls-speakers {
         padding-left: 89px;

--- a/docroot/sites/all/themes/ilr_theme/scss/layout/_sls_homepage_layout.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/layout/_sls_homepage_layout.scss
@@ -73,7 +73,13 @@ body.subsite-front {
       }
       #block-bean-sls-moderators {
         article.moderator {
-          @extend %four-column;
+          @extend %three-column;
+        }
+        .mod-last-row { //2 articles in last row
+          article.moderator {
+            @extend %two-column;
+            width: 42% !important;
+          }
         }
       }
       #block-bean-sls-speakers {


### PR DESCRIPTION
After deployment, a div with class "mod-last-row" will have to be added to the SLS Moderators html block on production to contain the last 2 articles.