### PR TITLE
Hide the Slack webhook for instagram exception notification

### DIFF
--- a/docroot/sites/all/modules/features/ilr_instagram_feed/ilr_instagram_feed.module
+++ b/docroot/sites/all/modules/features/ilr_instagram_feed/ilr_instagram_feed.module
@@ -24,8 +24,10 @@ function ilr_instagram_feed_feeds_after_import(FeedsSource $source) {
       'headers' => ['Content-Type' => 'application/json'],
     ];
 
-    $url = variable_get('ilr_instagram_feed_webhook_url', 'https://hooks.slack.com/services/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');
+    $url = variable_get('ilr_instagram_feed_webhook_url', getenv('INSTAGRAM_SLACK_WEBHOOK_URL'));
 
-    $result = drupal_http_request($url, $options);
+    if ($url) {
+      $result = drupal_http_request($url, $options);
+    }
   }
 }


### PR DESCRIPTION
No rush on this, as a new webhook URL was generated and set using `drush vset ilr_instagram_feed_webhook_url`, which should work with the existing code.