### PR TITLE
Add Editable Views module

### DIFF
--- a/docroot/sites/all/modules/contrib/editableviews/LICENSE.txt
+++ b/docroot/sites/all/modules/contrib/editableviews/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/docroot/sites/all/modules/contrib/editableviews/README.txt
+++ b/docroot/sites/all/modules/contrib/editableviews/README.txt
@@ -1,0 +1,27 @@
+Editable Views
+==============
+
+Editable Views lets you create Views where the fields can be edited. Fields show both the current value and a form to edit it. A 'Save' button allows saving of all the entities shown in the View (this is compatible with having exposed filters on the View).
+
+Editable fields can be added on the base entity as well as on entities brought into the View by a relationship. Other, non-editable fields may be added to the View, in which case they function normally.
+
+Currently, the following Views fields can be edited:
+- all FieldAPI fields
+- node title
+
+If a relationship is 'non-required', then it can bring empty data to the View. If there are editable fields on such a relationship, then it is possible to create new entities by entering data into those fields. However, the relationship must be of a sort that defines how to do this.
+
+Currently the following relationships are supported for creating new entities:
+- backward reference relationship on entityreference fields
+- forward relationships on entityreference fields
+
+Usage
+-----
+
+- Create a View, and set its style to 'Editable table'.
+- Add one or more editable fields
+
+Developer documentation
+-----------------------
+
+See the documentation page on drupal.org for developer documentation.

--- a/docroot/sites/all/modules/contrib/editableviews/editableviews.info
+++ b/docroot/sites/all/modules/contrib/editableviews/editableviews.info
@@ -1,0 +1,25 @@
+name = Editable Views
+description = Allows entity data in a view to be edited.
+package = Views
+dependencies[] = views
+dependencies[] = entity
+dependencies[] = ctools
+dependencies[] = field_ui
+core = 7.x
+files[] = editableviews_plugin_style_row_edit_table.inc
+files[] = handlers/editableviews_handler_field_field_edit.inc
+files[] = handlers/editableviews_handler_field_node_title_edit.inc
+files[] = handlers/editableviews_handler_field_entity_metadata_property.inc
+files[] = handlers/editableviews_handler_field_save_button_jump_link.inc
+
+files[] = tests/editableviews.test
+
+test_dependencies[] = entityreference
+test_dependencies[] = features
+
+; Information added by Drupal.org packaging script on 2015-07-28
+version = "7.x-1.0-beta10"
+core = "7.x"
+project = "editableviews"
+datestamp = "1438114140"
+

--- a/docroot/sites/all/modules/contrib/editableviews/editableviews.module
+++ b/docroot/sites/all/modules/contrib/editableviews/editableviews.module
@@ -1,0 +1,449 @@
+<?php
+/**
+ * @file editableviews.module
+ * Contain module code.
+ * @todo:
+ *  - some way to mark cells for a NEW entity? at least put a class on them!
+ *  - ditto, put class on relationship cells.
+ */
+
+/**
+ * Implements hook_views_api().
+ */
+function editableviews_views_api() {
+  return array(
+    'api' => '3.0-alpha1',
+    'path' => drupal_get_path('module', 'editableviews'),
+  );
+}
+
+/**
+ * Implements hook_forms().
+ *
+ * Handle our dynamic form IDs.
+ *
+ * @see editableviews_plugin_style_row_edit_table::get_form()
+ */
+function editableviews_forms($form_id, $args) {
+  // We only care about the first piece of the form ID here. Everything after
+  // that is only for the benefit of hook_form_alter().
+  $length = strlen('editableviews_entity_form');
+  if (substr($form_id, 0, $length) == 'editableviews_entity_form') {
+    $forms[$form_id] = array(
+      'callback' => 'editableviews_entity_form',
+    );
+    return $forms;
+  }
+}
+
+/**
+ * Form builder for an editable view.
+ *
+ * @see editableviews_forms()
+ *
+ * @param $entities
+ *  An array of entities to get the form for, keyed first by entity type and
+ *  then by entity id. The ids may be fake in the case of new, unsaved entities.
+ *  Furthermore, new entities should have a property
+ *  'editableviews_exposed_fields'. This should be an array of field names
+ *  corresponding to editable field handlers on the view. A value in at least
+ *  one of these fields on the entity causes it to be saved by
+ *  editableviews_entity_form_submit_save(). This allows the user
+ *  to leave a blank part of the result empty. However, it does not account for
+ *  the fact that there may be default values in the field widgets!
+ *  TODO: consider this problem!
+ * @param $results_coordinates
+ *  An array containing coordinates lookups for getting entity type and entity
+ *  from row id and relationship, and the same the other way round. Contains:
+ *  - 'entities_to_results': A nested array keyed by entity type then entity
+ *    id. The final values are flat arrays of the relationship id and result
+ *    index.
+ *  - 'results_to_entities': A nested array keyed by relationship id then
+ *    result index. The final values are flat arrays of the entity type and
+ *    entity id.
+ *  Conceptually, the pair (relationship id, result index) can be visualized as
+ *  the coordinates that specify which cells in the table the entity occupies:
+ *  the index gives the row and the relationship id one or more columns.
+ * @param $field_handlers
+ *  An array of the editable Views field handlers to show the form elements for.
+ *  This should be grouped by relationship ID, with the base table for the
+ *  view's base.
+ * @param $view
+ *  The view object.
+ */
+function editableviews_entity_form($form, &$form_state, $entities, $results_coordinates, $field_handlers, $view) {
+  // Include this here as it's fairly likely we have handlers that need it;
+  // rather than let the handler class include it over and over again.
+  ctools_include('fields');
+
+  //dsm(func_get_args(), 'form builder params');
+  //dsm($entities);
+  //dsm($field_handlers);
+
+  $form['#tree'] = TRUE;
+
+  $form['#entity_ids'] = array();
+  //$form['#field_names'] = $fields;
+  $form['#field_handlers'] = $field_handlers;
+
+  // Put these in the form in case custom form handlers need to look at them.
+  $form['#results_coordinates'] = $results_coordinates;
+
+  // Put the view name and display name on the form, for hook_form_alter().
+  $form['#view_name'] = $view->name;
+  $form['#view_display_name'] = $view->current_display;
+
+  // Get the message option from the view style plugin.
+  $form['#save_messages'] = $view->style_plugin->options['save_messages'];
+  // Get the batch option from the view style plugin.
+  $form['#batch'] = $view->style_plugin->options['batch'];
+  // Get the batch_size option from the view style plugin.
+  $form['#batch_size'] = $view->style_plugin->options['batch_size'];
+
+  foreach (array_keys($entities) as $entity_type) {
+    foreach ($entities[$entity_type] as $entity_id => $entity) {
+      if (isset($entity->language)) {
+        $langcode = field_valid_language($entity->language);
+      }
+      else {
+        $langcode = field_valid_language(NULL);
+      }
+
+      // Note we have to explicitly use the array key for the entity id rather
+      // than extract it here, because it might not actually be a real id for
+      // the case of an entity being created on a relationship.
+      list(, , $bundle) = entity_extract_ids($entity_type, $entity);
+
+      // Stash the entity type and id.
+      $form['#entity_ids'][$entity_type][] = $entity_id;
+
+      // Get the relationship that this entity is on. We only want to get form
+      // elements from the field handlers that are on this relationship.
+      list($relationship, $index) = $results_coordinates['entities_to_results'][$entity_type][$entity_id];
+
+      // Build up the per-entity subform.
+      $form[$entity_type][$entity_id] = array(
+        // This allows FieldAPI to have multiple field form elements attached.
+        '#parents' => array($entity_type, $entity_id),
+        '#entity_type' => $entity_type,
+        '#entity' => $entity,
+        '#bundle' => $bundle,
+        // Stash the relationship this entity is on, so this form's validate and
+        // submit handlers can get the relevant field handler for it.
+        '#views_relationship' => $relationship,
+      );
+
+      foreach ($field_handlers[$relationship] as $field_handler) {
+        // Pass the form to each field handler for it to add its element.
+        $field_handler->edit_form($entity_type, $entity, $form[$entity_type][$entity_id], $form_state);
+      }
+    }
+  }
+
+  $form['actions'] = array('#type' => 'actions');
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save'),
+  );
+
+  $form['#submit'] = array(
+    // We split the submit process up into the building of form values and the
+    // actual saving, to allow implementations of this to add extra processing
+    // steps in between, using hook_form_alter().
+    // For easier inserting of submit handlers, we key this array, which will
+    // not bother FormAPI at all (see form_execute_handlers()).
+    'build_values'  => 'editableviews_entity_form_submit_build_values',
+    'save'          => 'editableviews_entity_form_submit_save',
+  );
+
+  //dsm($form, 'end of form builder');
+  return $form;
+}
+
+/**
+ * Form validate handler.
+ *
+ * Adapted from fape_field_edit_field_form_validate().
+ */
+function editableviews_entity_form_validate($form, &$form_state) {
+  ctools_include('fields');
+
+  $field_handlers = $form['#field_handlers'];
+
+  // Act on each entity in turn.
+  foreach ($form['#entity_ids'] as $entity_type => $entity_ids) {
+    foreach ($entity_ids as $entity_id) {
+      $bundle = $form[$entity_type][$entity_id]['#bundle'];
+      $entity = $form[$entity_type][$entity_id]['#entity'];
+      $relationship = $form[$entity_type][$entity_id]['#views_relationship'];
+
+      // Start with a fresh errors array for each entity. FieldAPI field
+      // validation will add to this array.
+      $errors = array();
+
+      // Invoke the field handlers on the relationship the entity is on.
+      foreach ($field_handlers[$relationship] as $field_handler) {
+        $field_handler->edit_form_validate($entity_type, $entity, $form[$entity_type][$entity_id], $form_state, $errors);
+      }
+
+      // Invoke hook_field_attach_validate() to let other modules validate the
+      // entity. This should be done once only for each entity.
+      // Avoid module_invoke_all() to let $errors be taken by reference.
+      foreach (module_implements('field_attach_validate') as $module) {
+        $function = $module . '_field_attach_validate';
+        $function($entity_type, $entity, $errors);
+      }
+
+      if ($errors) {
+        // Pass FieldAPI validation errors back to widgets for accurate error
+        // flagging.
+        foreach ($field_handlers[$relationship] as $field_handler) {
+          // This is ugly, but only FieldAPI field handlers need this. The
+          // alternative would be for the editableviews_handler_field_field_edit
+          // handler's edit_form_validate() method to detect whether it's the
+          // last FieldAPI field handler for the current entity, which would be
+          // messier.
+          if (method_exists($field_handler, 'edit_form_validate_errors')) {
+            $field_handler->edit_form_validate_errors($entity_type, $entity, $form[$entity_type][$entity_id], $form_state, $errors);
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Form submit handler the first: build entities from field values.
+ *
+ * Entities are flagged as needing to be saved by our other submit handler,
+ * editableviews_entity_form_submit_save().
+ *
+ * Existing entities are flagged if they have editable fields on them.
+ *
+ * New entities are checked to see whether they need to be saved or not. This
+ * allows the user to leave a new entity's form elements empty to indicate they
+ * do not wish to create an entity in that space.
+ * Note however that this means if FieldAPI fields have default values, and
+ * these are left in the form, the entity will be created! There is no real
+ * way that I can envisage to account for this, short of adding a form element
+ * with a checkbox for the user to explicitly say a new entity should be saved.
+ * TODO: consider implementing this.
+ */
+function editableviews_entity_form_submit_build_values($form, &$form_state) {
+  ctools_include('fields');
+
+  //dsm($form);
+  //dsm($form_state, 'fs');
+
+  $field_handlers = $form['#field_handlers'];
+  // Act on each entity in turn.
+  foreach ($form['#entity_ids'] as $entity_type => $entity_ids) {
+    foreach ($entity_ids as $entity_id) {
+      $bundle = $form[$entity_type][$entity_id]['#bundle'];
+      $entity = $form[$entity_type][$entity_id]['#entity'];
+      $relationship = $form[$entity_type][$entity_id]['#views_relationship'];
+
+      // Invoke the field handlers on the relationship the entity is on, if any.
+      foreach ($field_handlers[$relationship] as $field_handler) {
+        $field_handler->edit_form_submit($entity_type, $entity, $form[$entity_type][$entity_id], $form_state);
+      }
+
+      // Set our flag on the entity if it needs to be saved.
+      if (is_numeric($entity_id)) {
+        // For existing entities, we save if the entity had editable fields
+        // in the view. This does mean that an entity could be saved needlessly,
+        // as we don't compare old values with incoming form values.
+        if (count($field_handlers[$relationship])) {
+          $entity->editableviews_needs_save = TRUE;
+        }
+      }
+      else {
+        // For new entities, check they have had values set on them by the user
+        // that justify saving them.
+        $wrapper = entity_metadata_wrapper($entity_type, $entity);
+        foreach ($entity->editableviews_exposed_fields as $expected_field_name) {
+          // We have to use the wrapper, as FieldAPI fields will contain a
+          // nested array with the langcode even if left empty.
+          $value = $wrapper->{$expected_field_name}->raw();
+          if (!empty($value)) {
+            // If there is a value, mark this entity as needing to be saved by
+            // editableviews_entity_form_submit_save(). Obviously, custom
+            // form submit handlers that come after us are free to remove or
+            // force this.
+            $entity->editableviews_needs_save = TRUE;
+            // No point going any further.
+            break;
+          }
+        }
+      }
+
+      // Put the entities in the form state for the subsequent submit handlers to
+      // find. Key by entity type to make it easy to get hold of that.
+      $form_state['entities'][$entity_type][$entity_id] = $entity;
+    }
+  }
+}
+
+/**
+ * Form submit handler the second: save entities.
+ *
+ * Saves all entities in $form_state['entities'], with the exception of new
+ * entities which have their 'editableviews_needs_save' set to FALSE.
+ * If batch support is enabled, batch is triggered from here.
+ */
+function editableviews_entity_form_submit_save($form, &$form_state) {
+  if (!$form['#batch']) {
+    editableviews_entity_save($form_state['entities'], $form['#save_messages']);
+  }
+  else {
+    $operations = array();
+    $entities = $form_state['entities'];
+    foreach (array_keys($entities) as $entity_type) {
+      $entity_array = $entities[$entity_type];
+      while (!empty($entity_array)) {
+        $list = array_splice($entity_array, 0, $form['#batch_size']);
+
+        $operations[] = array(
+          'editableviews_entity_save',
+          array(
+            array($entity_type => $list),
+            $form['#save_messages'],
+          )
+        );
+      }
+    }
+
+    $batch = array(
+      'operations' => $operations,
+      'finished' => 'editableviews_save_batch_finished',
+    );
+
+    batch_set($batch);
+  }
+}
+
+/**
+ * Implements callback_batch_finished().
+ */
+function editableviews_save_batch_finished($success, $results, $operations) {
+  if ($success) {
+    drupal_set_message(t('Entities saved successfully'));
+  }
+  else {
+    drupal_set_message(t('An error occurred while saving entities'), 'error');
+  }
+}
+
+/**
+ * Saves the entities in $entities array.
+ *
+ * @param array $entities
+ *   Entities to save.
+ * @param string $save_messages
+ *   Configuration setting about messages to show to end users. It must be one
+ *   of the values below:
+ *     - 'none': Show no messages.
+ *     - 'summary': Show a single message summarizing the changes.
+ *     - 'individual': Show a message for each saved entity.
+ */
+function editableviews_entity_save($entities, $save_messages) {
+  $entity_info = entity_get_info();
+  $save_message_labels = array();
+  foreach (array_keys($entities) as $entity_type) {
+    foreach ($entities[$entity_type] as $entity_id => $entity) {
+      // Check whether a save has been requested.
+      if (empty($entity->editableviews_needs_save)) {
+        continue;
+      }
+
+      // Save the entity using Entity API.
+      entity_save($entity_type, $entity);
+
+      // If the entity was a new one, and on a forward relationship, we need
+      // to set the referring entity to point to it. We can do this now that the
+      // new entity has been saved and has an id.
+      if (isset($entity->editableviews_future_reference)) {
+        list($new_entity_id,) = entity_extract_ids($entity_type, $entity);
+
+        $referring_entity = $entities[$entity->editableviews_future_reference['entity_type']][$entity->editableviews_future_reference['entity_id']];
+        $wrapper = entity_metadata_wrapper($entity->editableviews_future_reference['entity_type'], $referring_entity);
+
+        // Make the existing entity point to the new entity.
+        $relationship_field_name = $entity->editableviews_future_reference['field_name'];
+        $wrapper->{$relationship_field_name}->set($new_entity_id);
+
+        // This needs to be saved a second time, as there's no simple way we can
+        // guarantee the order we come to these in: they are in the order we
+        // encounter them going through the field handlers.
+        entity_save($entity->editableviews_future_reference['entity_type'], $referring_entity);
+      }
+
+      if ($save_messages == 'individual') {
+        // Show a confirmation message. This could get pretty long on a big View!
+        drupal_set_message(t("Saved %entity-type entity %label.", array(
+          '%entity-type' => $entity_info[$entity_type]['label'],
+          '%label' => entity_label($entity_type, $entity),
+        )));
+      }
+      elseif ($save_messages == 'summary') {
+        // Use drupal_placeholder() to format this the same as %label above.
+        $save_message_labels[] = drupal_placeholder(entity_label($entity_type, $entity));
+      }
+    }
+  }
+
+  if ($save_messages == 'summary' && count($save_message_labels)) {
+    drupal_set_message(t("Saved entities !labels.", array(
+      // These have been sanitized already.
+      '!labels' => implode(', ', $save_message_labels),
+    )));
+  }
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function editableviews_module_implements_alter(&$implementations, $hook) {
+  if ($hook == 'views_data_alter') {
+    // Move our hook_views_data_alter() to the end of the list, so we can
+    // doctor relationships provided by other modules.
+    $group = $implementations['editableviews'];
+    unset($implementations['editableviews']);
+    $implementations['editableviews'] = $group;
+  }
+}
+
+// ================================================= Sample form alteration.
+
+/**
+ * Implements hook_form_FORM_ID_alter(): editableviews_entity_form_test_vre_fields
+ */
+/*
+function editableviews_form_editableviews_entity_form_test_vre_fields_alter(&$form, &$form_state, $form_id) {
+  // Faffily insert our submit handler after the 'build_values' one.
+  $new_submit = array();
+  foreach ($form['#submit'] as $key => $submit) {
+    $new_submit[$key] = $submit;
+    if ($key == 'build_values') {
+      $new_submit['ours'] = 'mymodule_editableviews_form_submit';
+    }
+  }
+  $form['#submit'] = $new_submit;
+}
+*/
+
+/**
+ * Custom form submit handler.
+ */
+/*
+function mymodule_editableviews_form_submit($form, &$form_state) {
+  foreach (array_keys($form_state['entities']) as $entity_type) {
+    foreach ($form_state['entities'][$entity_type] as $entity_id => $entity) {
+      // Change something on the entity before it is saved.
+      $entity->uid = 1;
+      // Remove an entity from saving entirely.
+      unset($form_state['entities'][$entity_type][115]);
+    }
+  }
+}
+*/

--- a/docroot/sites/all/modules/contrib/editableviews/editableviews.views.inc
+++ b/docroot/sites/all/modules/contrib/editableviews/editableviews.views.inc
@@ -1,0 +1,161 @@
+<?php
+/**
+ * @file editableviews.views.inc
+ * Contains Views hooks.
+ */
+
+/**
+ * Implements hook_views_plugins().
+ */
+function editableviews_views_plugins() {
+  $plugins = array();
+  $plugins['style'] = array(
+    'editableviews_table' => array(
+      'title' => t('Editable table'),
+      'help' => t('Displays a table whose fields can be edited.'),
+      'handler' => 'editableviews_plugin_style_row_edit_table',
+      'theme' => 'views_view_table',
+      'theme path' => drupal_get_path('module', 'views') . '/theme',
+      'uses row class' => TRUE,
+      'uses fields' => TRUE,
+      'uses options' => TRUE,
+      'type' => 'normal',
+      'help topic' => 'style-table',
+    ),
+  );
+
+  return $plugins;
+}
+
+/**
+ * Implements hook_views_data_alter().
+ *
+ *  - Add editable field handlers.
+ *  - Set the direction on entityreference reverse relationships.
+ */
+function editableviews_views_data_alter(&$data) {
+  // We're going to need this.
+  $entity_info = entity_get_info();
+
+  // Editable fields for FieldAPI fields.
+  foreach (field_info_fields() as $field) {
+    if ($field['storage']['type'] != 'field_sql_storage') {
+      continue;
+    }
+
+    // Because we act in a way analogous to Views' default views_data helper,
+    // field_views_field_default_views_data(), we should consider checking
+    // that the field's module doesn't implement hook_field_views_data(),
+    // because if it does, it possibly means our one-size-fits-all approach
+    // here is unsuitable for the field. TODO!
+
+    $table = _field_sql_storage_tablename($field);
+    $column = $field['field_name'];
+    $keys = array_keys($field['columns']);
+    $real_field = reset($keys);
+
+    // Some fields just aren't there, such as OG ones.
+    if (!isset($data[$table][$column])) {
+      continue;
+    }
+
+    // Copy the UI texts from the original field. We don't copy the whole
+    // array because that will have other, unwanted, handler types on it.
+    $new_field_name = $column . '_editable';
+    $data[$table][$new_field_name] = array(
+      'group'       => $data[$table][$column]['group'],
+      'title'       => $data[$table][$column]['title'] . ' ' . t('(editable)'),
+      'title short' => $data[$table][$column]['title short'],
+      // TODO: add detail here.
+      'help'        => $data[$table][$column]['help'],
+    );
+
+    $data[$table][$new_field_name]['field'] = $data[$table][$column]['field'];
+    $data[$table][$new_field_name]['field']['handler'] = 'editableviews_handler_field_field_edit';
+  } // foreach field_info_fields()
+
+  // Editable field for entity metadata properties. Only properties with a
+  // defined 'setter callback' may be used.
+  // We define a single pseudofield, and set the particular property at the
+  // handler options level, as depending on metadata properties here is quite
+  // likely weirdly circular.
+  foreach ($entity_info as $entity_type => $entity_type_info) {
+    if (!empty($entity_type_info['base table']) && isset($data[$entity_type_info['base table']])) {
+      $data[$entity_type_info['base table']]['metadata_property_editable'] = array(
+        'title' => t("Entity metadata property (editable)"),
+        'help' => t("Editable field for entity metadata properties that have setter callbacks defined."),
+        'field' => array(
+          'real field' => $entity_type_info['entity keys']['id'],
+          'handler' => 'editableviews_handler_field_entity_metadata_property',
+        ),
+      );
+    }
+  }
+
+  // Node title editable field.
+  $data['node']['title_editable'] = array(
+    'title' => $data['node']['title']['title'] . ' ' . t('(editable)'),
+    'help'  => $data['node']['title']['help'],
+  );
+  $data['node']['title_editable']['field'] = $data['node']['title']['field'];
+  $data['node']['title_editable']['field']['handler'] = 'editableviews_handler_field_node_title_edit';
+
+  // Define the direction of entityreference reverse relationships.
+  // This is set by entityreference module in the magic callback on the field,
+  // hook_field_views_data_views_data_alter(). This is invoked by Field module's
+  // hook_views_data_alter(). Unfortunately, unlike Field module's
+  // hook_views_data() there is no drupal_alter() of the resulting data.
+  // Therefore our only way to alter it is here. Extremely fortunately, it
+  // appears to already be here in the data at this point and module weight
+  // does not seem to be an issue!
+  foreach (field_info_fields() as $field) {
+    if ($field['type'] == 'entityreference') {
+      // This repeats much of the code in
+      // entityreference_field_views_data_views_data_alter().
+      foreach ($field['bundles'] as $entity_type => $bundles) {
+        $target_entity_type = $field['settings']['target_type'];
+        if (isset($entity_info[$target_entity_type]['base table'])) {
+          $target_entity_info = $entity_info[$target_entity_type];
+          $pseudo_field_name = 'reverse_' . $field['field_name'] . '_' . $entity_type;
+          $data[$target_entity_info['base table']][$pseudo_field_name]['relationship']['editableviews_direction'] = 'reverse';
+        }
+      }
+    }
+  }
+
+  // Save button jump link field.
+  $data['views']['editableviews_jump_link'] = array(
+    'title' => t('Editable view save button jump link'),
+    'help' => t('Ouputs a jump link to the save button at the bottom of the view.'),
+    'field' => array(
+      'handler' => 'editableviews_handler_field_save_button_jump_link',
+    ),
+  );
+}
+
+/**
+ * Implement hook_field_views_data_alter.
+ *
+ * Define the direction of entityreference forward relationships.
+ *
+ * Watch carefully: this is called by Field module's hook_views_data() to alter
+ * the Views data definition for a single field, either as given by the field
+ * module itself with hook_field_views_data(), or by default values. In our
+ * case, we're altering entityreference field data defined in
+ * entityreference_field_views_data().
+ */
+function editableviews_field_views_data_alter(&$data, $field, $module) {
+  // Bail for anything else.
+  if ($module != 'entityreference') {
+    return;
+  }
+
+  // There will be more than one table (node revisions). But we only care about
+  // the real one.
+  $table_name = _field_sql_storage_tablename($field);
+  $field_name = $field['field_name'] . '_target_id';
+
+  $data[$table_name][$field_name]['relationship']['editableviews_direction'] = 'forward';
+  // This is mysteriously missing from Entityreference!
+  $data[$table_name][$field_name]['relationship']['field_name'] = $field['field_name'];
+}

--- a/docroot/sites/all/modules/contrib/editableviews/editableviews_plugin_style_row_edit_table.inc
+++ b/docroot/sites/all/modules/contrib/editableviews/editableviews_plugin_style_row_edit_table.inc
@@ -1,0 +1,724 @@
+<?php
+
+/**
+ * Plugin class for the Editable Table style.
+ */
+class editableviews_plugin_style_row_edit_table extends views_plugin_style_table {
+
+  /**
+   * Initialize a style plugin.
+   */
+  function init(&$view, &$display, $options = NULL) {
+    parent::init($view, $display, $options);
+
+    // Get the helper object. This abstracts out a number of things we do here,
+    // in order that other style plugins can use them too.
+    $this->helper = new editableviews_style_helper($this);
+  }
+
+  function option_definition() {
+    $options = parent::option_definition();
+
+    // Todo: this should technically be on the helper, but it's faffy as it
+    // is apparently not always there, if Views code with the same
+    // pattern is anything to go by!
+    $options['relationship_creation_bundle'] = array('default' => array());
+    $options['save_messages'] = array('default' => 'individual');
+    $options['batch'] = array('default' => FALSE, 'bool' => TRUE);
+    $options['batch_size'] = array('default' => 10);
+
+    return $options;
+  }
+
+  /**
+   * The options form for the given style.
+   */
+  function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    // Everything we add to the options form is common and thus in the helper.
+    $this->helper->options_form($form, $form_state);
+  }
+
+  function validate() {
+    $errors = parent::validate();
+
+    $relationship_handlers = $this->display->handler->get_handlers('relationship');
+    $field_handlers_grouped = $this->helper->get_editable_field_handlers_grouped();
+    //dsm($field_handlers_grouped);
+
+    foreach ($relationship_handlers as $relationship_id => $relationship_handler) {
+      // We don't care about required relationships.
+      if ($relationship_handler->options['required']) {
+        continue;
+      }
+
+      //dsm($relationship_handler);
+
+      // We don't care if there are no editable fields on the relationship.
+      if (empty($field_handlers_grouped[$relationship_id])) {
+        continue;
+      }
+
+      if (!isset($relationship_handler->definition['editableviews_direction'])) {
+        $errors[] = t("The relationship '@relationship' is not compatible with editable fields that may cause creation of entities for empty data. The relationship should be set to be 'required'.", array(
+          '@relationship' => $relationship_handler->options['label']
+        ));
+      }
+
+      if (!isset($this->options['relationship_creation_bundle'][$relationship_id])) {
+        $errors[] = t("Display @display is set to use a editable fields and the '@relationship' relationship is not set to be required: the bundle of entities to create on this relationship must be set in the Editable Table options.", array(
+          '@display' => $this->display->display_title,
+          '@relationship' => $relationship_handler->options['label']
+        ));
+      }
+    }
+
+    return $errors;
+  }
+
+  /**
+   * Add anything to the query that we might need to.
+   */
+  function query() {
+    parent::query();
+
+    // Everything we do to the query is common and thus in the helper.
+    $this->helper->query();
+  }
+
+  /**
+   * Helper to get the handlers for editable fields.
+   *
+   * @return
+   *  An array of field handlers, in the same format as get_handlers() returns,
+   *  but containing only those handlers which are for editable fields.
+   */
+  function get_edit_field_handlers() {
+    $handlers = $this->display->handler->get_handlers('field');
+
+    $edit_field_handlers = array();
+    foreach ($handlers as $key => $handler) {
+      if (!empty($handler->editable)) {
+        $edit_field_handlers[$key] = $handler;
+      }
+    }
+
+    return $edit_field_handlers;
+  }
+
+  /**
+   * Render all of the fields for a given style and store them on the object.
+   *
+   * @param $result
+   *   The result array from $view->result
+   */
+  function render_fields($result) {
+    if (!$this->uses_fields()) {
+      return;
+    }
+
+    if (!isset($this->rendered_fields)) {
+      parent::render_fields($result);
+
+      $this->insert_form_elements($result);
+    }
+
+    return $this->rendered_fields;
+  }
+
+  /**
+   * Insert the field form elements into the rendered View fields.
+   *
+   * @param $result
+   *   The result array from $view->result
+   */
+  function insert_form_elements($result) {
+    //dsm($result, '$result');
+    // Get our edit field handlers.
+    $edit_field_handlers = $this->get_edit_field_handlers();
+    if (empty($edit_field_handlers)) {
+      // There's nothing to do!
+      return;
+    }
+    //dsm($edit_field_handlers, '$edit_field_handlers');
+    $relationship_handlers = $this->display->handler->get_handlers('relationship');
+
+    //dsm($this->view->relationship);
+
+    // Build an array of the field names to make editable.
+    // The keys are the id keys of the Views handlers.
+    // For non-field-API fields, the definition must include this property.
+    $edit_fields = array();
+    // Create the keys in this so they exist even for relationships with no
+    // editable fields.
+    $edit_field_handlers_grouped = array_fill_keys(array_keys($relationship_handlers), array());
+    $edit_field_handlers_grouped[$this->view->base_table] = array();
+
+    foreach ($edit_field_handlers as $handler_id => $handler) {
+      //dsm($handler, "field handler $handler_id");
+      $edit_fields[$handler_id] = $handler->field_name();
+
+      // Build an array of handlers grouped by relationship ID.
+      // This is for the form builder to only work on the handlers that are
+      // relevant to the entity's relationship.
+      $field_handler_relationship_id = $handler->options['relationship'];
+      if ($field_handler_relationship_id == 'none') {
+        $field_handler_relationship_id = $this->view->base_table;
+      }
+
+      $edit_field_handlers_grouped[$field_handler_relationship_id][$handler_id] = $handler;
+    }
+
+    // Build an array of entities that we should be working with. We load the
+    // that are implicit in the view result, creating new ones if there are any
+    // gaps.
+    // The entity ID fields have been added to the view result by query().
+    $result_entities = array();
+    foreach ($result as $index => $result_row) {
+      foreach ($this->helper->relationship_entity_fields as $relationship_id => $relationship_entity_data) {
+        $entity_type = $relationship_entity_data['entity_type'];
+        // Get the entity ID out of the result.
+        $entity_id = $result_row->{$relationship_entity_data['id_field_alias']};
+
+        // Get the entities we work with, and build an array of them.
+        if (isset($entity_id)) {
+          $entity = entity_load_single($entity_type, $entity_id);
+
+          $result_entities[$entity_type][$entity_id] = $entity;
+        }
+        else {
+          if (count($edit_field_handlers_grouped[$relationship_id])) {
+            // If there is no entity, and the relationship has editable fields,
+            // we create one (i.e., make the object without saving it). We give
+            // this a fake entity id, composed of the relationship handler id
+            // and the index so it's unique.
+            $entity_id = $relationship_id . ':' . $index;
+
+            $entity = $this->helper->entity_create($relationship_id);
+
+            $result_entities[$entity_type][$entity_id] = $entity;
+          }
+        }
+
+        // Build a lookup from entity type and entity to the result row index
+        // and relationship. It helps to conceptualize this as giving us
+        // coordinates for where the entity has fields in the view table:
+        // the index gives the row, and the relationship gives the column(s).
+        // This is for the form builder to be able to get to the right result
+        // row and to know which handlers to get form elements from.
+        $result_indexes[$entity_type][$entity_id] = array($relationship_id, $index);
+
+        // Build a lookup array of the same coordinates, but towards the entity:
+        // keys are relationship ID then index, values are entity type and entity.
+        $result_indexes_reverse[$relationship_id][$index] = array($entity_type, $entity_id);
+      }
+    }
+    //dsm($result_entities, '$result_entities');
+    //dsm($result_indexes_reverse, '$result_indexes_reverse');
+
+    // Make a combined array of coordinate lookups, both forward and reverse.
+    // TODO: eventually replace everything to work with this arrays instead of
+    // the two separate ones.
+    $results_coordinates = array(
+      'entities_to_results' => $result_indexes,
+      'results_to_entities' => $result_indexes_reverse,
+    );
+
+    // Build up some lookups pertaining to field handlers, and set the editable
+    // fields on new entities.
+    $result_entity_ids = array();
+    foreach ($result as $index => $result_row) {
+      foreach ($edit_field_handlers as $handler_id => $handler) {
+        // Get the entity type and entity for this field handler from the
+        // relationship lookup.
+        $field_handler_relationship_id = $handler->options['relationship'];
+        if ($field_handler_relationship_id == 'none') {
+          $field_handler_relationship_id = $this->view->base_table;
+        }
+
+        // Add the field_name for this field handler to the list on the entity
+        // which keeps track of them.
+        list($entity_type, $entity_id) = $result_indexes_reverse[$field_handler_relationship_id][$index];
+        if (!is_numeric($entity_id)) {
+          $entity = $result_entities[$entity_type][$entity_id];
+          $entity->editableviews_exposed_fields[] = $handler->field_name();
+        }
+
+        // Build a lookup array from index and field handler to the entity type
+        // and entity. This is to get to the right form element to include when
+        // we finally render our fields.
+        // Just get the entity coordinates from the relationship lookup.
+        $result_entity_ids[$index][$handler_id] = $result_indexes_reverse[$field_handler_relationship_id][$index];
+      }
+    }
+    //dsm($result_entity_ids, '$result_entity_ids');
+
+    // Now we have built up all our entities, go over them again and add
+    // the connecting properties to any new ones.
+    // In other words:
+    //  - On a forward relationship, the existing entity on the relationship's
+    //    base needs to point to the new entity that is (potentially) about to
+    //    be saved.
+    //  - On a reverse relationship, the new entity that is about to be created
+    //    needs to point back to the existing entity on the relationship's base.
+    // Here we figure out the id we need to point to, and the property to point
+    // to it in.
+    $this->helper->connect_new_entities($result_entities, $results_coordinates, $edit_field_handlers_grouped);
+    //dsm($result_entities, '$result_entities post connect');
+
+    // Load up the form render array.
+    $this->get_form($result_entities, $results_coordinates, $edit_field_handlers_grouped);
+
+    // Doctor the view's rendered fields to add in the form elements for
+    // the appropriate entity and field.
+    foreach ($this->rendered_fields as $index => $rendered_fields) {
+      foreach ($edit_fields as $handler_id => $field_name) {
+        // Get the already rendered field.
+        $rendered_field = $this->rendered_fields[$index][$handler_id];
+
+        // Get the entity type and entity that this field handler shows from our
+        // lookup array, so that we can pick out the form element to render
+        // for it.
+        list($entity_type, $entity_id) = $result_entity_ids[$index][$handler_id];
+
+        // TODO! theme this!!
+        $this->rendered_fields[$index][$handler_id] = '<div class="views-row-edit-static">' . $rendered_field . '</div>';
+        $this->rendered_fields[$index][$handler_id] .= '<div class="views-row-edit-edit">' . drupal_render($this->form[$entity_type][$entity_id][$field_name]) . '</div>';
+      }
+    }
+  }
+
+  /**
+   * Helper method. Retrieves the form render array.
+   *
+   * @param $entities
+   *  An array of entities to get the form for, keyed first by entity type and
+   *  then by entity id.
+   * @param $results_coordinates
+   *  An array containing coordinates lookups for getting entity type and entity
+   *  from row id and relationship, and the same the other way round. Contains:
+   *  - 'entities_to_results': A nested array keyed by entity type then entity
+   *    id. The final values are flat arrays of the relationship id and result
+   *    index.
+   *  - 'results_to_entities': A nested array keyed by relationship id then
+   *    result index. The final values are flat arrays of the entity type and
+   *    entity id.
+   * @param $edit_field_handlers
+   *  An array of field handlers to provide form elements for, grouped by
+   *  their relationship.
+   *  See editableviews_entity_form() for details.
+   */
+  function get_form($entities, $results_coordinates, $edit_field_handlers) {
+    // Create a dynamic form ID using the base name (for quick recognition
+    // in hook_forms()) and the view name. This allows hook_form_alter() to
+    // target forms for specific views. We don't add the display name as there's
+    // no clean way to mark the separation between that and the view name.
+    // @see editableviews_forms()
+    $form_id = 'editableviews_entity_form' . '_' . $this->view->name;
+
+    // We store this rather than return it, as it's used in different places.
+    $this->form = drupal_get_form($form_id, $entities, $results_coordinates, $edit_field_handlers, $this->view);
+  }
+
+  /**
+   * Render the display in this style.
+   */
+  function render() {
+    // Get the rendered view output.
+    $view_render = parent::render();
+
+    // Stick it INSIDE the form as plain markup, so that the HTML FORM element
+    // goes around everything.
+    $this->form['view'] = array(
+      '#markup' => $view_render,
+    );
+
+    return $this->form;
+  }
+
+}
+
+/**
+ * Helper class for the style plugin.
+ *
+ * This abstracts out a number of things the style plugin needs to do, in order
+ * that other style plugins can use them too.
+ */
+class editableviews_style_helper {
+
+  /**
+   * A lookup from relationships to the data needed to load their entities.
+   *
+   * This is an array of the relationships on the view which correspond to
+   * entity base tables, including the base table (as a pseudo-relationship).
+   * The key is the relationship id (in the case of the base table, this is just
+   * the table name itself). Each value is an array containing:
+   *  - 'entity_type': The entity type this relationship brings to the view.
+   *  - 'id_field_alias': The field alias of the field on the view in which to
+   *    find the entity's ID. This field is ensured by our query().
+   */
+  public $relationship_entity_fields = array();
+
+  function __construct(&$plugin) {
+    $this->plugin = &$plugin;
+  }
+
+  /**
+   * Provide common options for editable style plugins.
+   */
+  function options_form(&$form, &$form_state) {
+    // Add a fieldset to allow setting of a creation bundle for all the
+    // relationships that are non-required. This is because a non-required
+    // relationship may cause empty data in the result, and if this has editable
+    // fields, then entering data into those field's form elements causes the
+    // creation of a new entity. Which we need a bundle for.
+    $relationship_handlers = $this->plugin->display->handler->get_handlers('relationship');
+    // Get our edit field handlers.
+    $edit_field_handlers = $this->plugin->get_edit_field_handlers();
+
+    // Collect the relationships these are on.
+    $edit_relationship_handlers = array();
+    foreach ($edit_field_handlers as $field_handler_id => $field_handler) {
+      // Because we're not in the process of querying, the relationship is only
+      // set in the options.
+      $relationship_id = $field_handler->options['relationship'];
+
+      // Skip edit field handlers that are on the base.
+      if ($relationship_id == 'none') {
+        continue;
+      }
+
+      // Argh, do we need to contend with the alias of the relationship here??
+
+      // Skip a relationship that is required: these will never provide an empty
+      // row, and so never require entity creation.
+      if ($relationship_handlers[$relationship_id]->options['required']) {
+        continue;
+      }
+
+      // If we're still here, this is a relationship we need to consider.
+      $edit_relationship_handlers[$relationship_id] = $relationship_handlers[$relationship_id];
+    }
+
+    // Only show this fieldset if there are relationships to consider.
+    if (count($edit_relationship_handlers)) {
+      $form['relationship_creation_bundle'] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Relationship entity creation bundles'),
+        '#description' => t('A relationship which is set to not required may produce empty form elements, which thus require the creation of a new entity if populated with data. The bundle for these new entities must be specified here.'),
+        '#weight' => -1,
+      );
+
+      foreach ($edit_relationship_handlers as $relationship_id => $relationship_handler) {
+        // The 'base' of a relationship is the table it brings.
+        $table = $relationship_handler->definition['base'];
+        // Get the entity type from the table.
+        $table_data = views_fetch_data($table);
+        $entity_type = $table_data['table']['entity type'];
+        $entity_info = entity_get_info($entity_type);
+
+        $options = array();
+        foreach ($entity_info['bundles'] as $bundle => $bundle_info) {
+          $options[$bundle] = $bundle_info['label'];
+        }
+
+        $form['relationship_creation_bundle'][$relationship_id] = array(
+          '#type' => 'select',
+          '#title' => t('Bundle for new entities created on %label', array(
+            '%label' => $relationship_handler->options['label'],
+          )),
+          '#description' => t('Select the %entity entity bundle for entities created on this relationship.', array(
+            '%entity' => $entity_info['label'],
+          )),
+          '#options' => $options,
+          '#required' => TRUE,
+        );
+        // We have to check the default value, as the key in the array is variable
+        // because it's the relationship handler ID. That means that Views won't
+        // have it set in option_definition().
+        if (isset($this->plugin->options['relationship_creation_bundle'][$relationship_id])) {
+          $form['relationship_creation_bundle'][$relationship_id]['#default_value'] = $this->plugin->options['relationship_creation_bundle'][$relationship_id];
+        }
+      }
+    }
+
+    $form['save_messages'] = array(
+      '#type' => 'select',
+      '#title' => t("Save messages"),
+      '#description' => t('The messages to show the user when the view form is saved.'),
+      '#options' => array(
+        'none' => t('Show no messages'),
+        'summary' => t('Show a single message summarizing the changes'),
+        'individual' => t('Show a message for each saved entity'),
+      ),
+      '#default_value' => $this->plugin->options['save_messages'],
+    );
+
+    $form['batch'] = array(
+      '#type' => 'checkbox',
+      '#title' => t("Enable batch support"),
+      '#description' => t('Use Batch API to save huge data.'),
+      '#default_value' => $this->plugin->options['batch'],
+    );
+
+    $form['batch_size'] = array(
+      '#type' => 'textfield',
+      '#title' => t("Batch size"),
+      '#description' => t('Number of entities to process in each batch step.'),
+      '#default_value' => $this->plugin->options['batch_size'],
+      '#states'=> array(
+        'visible' => array(
+          ':input[name="style_options[batch]"]' => array('checked' => TRUE),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Add anything to the query that we might need to.
+   *
+   * For the base and each relationship that brings an entity table, add the
+   * entity ID field for that entity. This ensures that we can load the entities
+   * when we need to get form elements for them.
+   *
+   * We do this for all relationships, not just those which have editable fields
+   * on them, because we may need access to entities that editable field
+   * entities need to point to when creating entities.
+   */
+  function query() {
+    // For each relationship that provides an entity table (including the base
+    // pseudo-relationship), add the field for that entity's ID.
+    $base_table = $this->plugin->view->base_table;
+
+    // Do the View base first.
+    $table_data = views_fetch_data($this->plugin->view->base_table);
+    if (isset($table_data['table']['entity type'])) {
+      // We don't need to ensure this field is on the query: the id field on
+      // the base table always is.
+      $this->relationship_entity_fields[$base_table] = array(
+        'entity_type' => $table_data['table']['entity type'],
+        // We don't need to find an alias for a field on the base.
+        'id_field_alias' => $table_data['table']['base']['field'],
+      );
+    }
+
+    // Now the relationships.
+    $relationship_handlers = $this->plugin->display->handler->get_handlers('relationship');
+    foreach ($relationship_handlers as $relationship_id => $relationship_handler) {
+      //dsm($relationship_handler, $relationship_id);
+
+      // The 'base' of a relationship is the table it brings.
+      $table = $relationship_handler->definition['base'];
+      // Get the entity type from the table.
+      $table_data = views_fetch_data($table);
+
+      if (!isset($table_data['table']['entity type'])) {
+        // Not an entity base table relationship: skip it.
+        continue;
+      }
+
+      // Get the entity type and the views field that corresponds to the entity
+      // id from the table definition.
+      //dsm($table_data['table'], 'table data');
+      $entity_type = $table_data['table']['entity type'];
+      $entity_id_field = $table_data['table']['base']['field'];
+
+      // Force the 're
+      if ($relationship_handler->options['relationship'] == 'none') {
+        $relationship_relationship = $base_table;
+      }
+      else {
+        $relationship_relationship = $relationship_handler->options['relationship'];
+      }
+      //dsm($relationship_relationship, '$relationship_relationship');
+
+      // We want the alias for the table the relationship brings, not the table
+      // it sits on.
+      $table_alias = $relationship_handler->alias;
+      //dsm("$relationship_id brings $entity_type, $entity_id_field.\ntable alias is $table_alias");
+
+      $entity_id_field_alias = $this->plugin->view->query->add_field($table_alias, $entity_id_field);
+
+      $this->relationship_entity_fields[$relationship_id] = array(
+        'entity_type' => $entity_type,
+        'id_field_alias' => $entity_id_field_alias,
+      );
+    }
+    //dsm($this->relationship_entity_fields);
+  }
+
+  /**
+   * Returns a new (unsaved) entity for the given relationship ID.
+   *
+   * This is needed when editable field handlers are on a non-required
+   * relationship, and a particular result row has no data there. We create a
+   * new entity for FieldAPI to work on, and potentially save it on submission
+   * if the user enters data.
+   *
+   * @param $relationship_id
+   *  The id of the relationship that requires a new entity.
+   *
+   * @return
+   *  A new, unsaved entity. The entity type is implied by the handler, and
+   *  should be known by the caller. The bundle will be set on this, given by
+   *  the style plugin's options.
+   */
+  function entity_create($relationship_id) {
+    $entity_type = $this->relationship_entity_fields[$relationship_id]['entity_type'];
+
+    // This is complex. We know the entity type, but we need to be told
+    // the bundle: that's one for the plugin settings.
+    // Then when it's created, we need to know how to set the relationship
+    // field.
+    $entity_info = entity_get_info($entity_type);
+    // Assume this exists, as it must do if the entity is fieldable, and
+    // if your entity is not fieldable, what are you doing here? ;)
+    $bundle_key = $entity_info['entity keys']['bundle'];
+
+    $values = array(
+      // The bundle of the new entity is set in the options for this
+      // style plugin. This has to be set by the user, because there is
+      // absolutely no other way to sniff this out!
+      // TODO: cloud cuckoo land, but a form element field to specify
+      // the bundle for each row would be nice!
+      $bundle_key => $this->plugin->options['relationship_creation_bundle'][$relationship_id],
+    );
+
+    // Just a little bit of sugar to save this having to be done in a custom
+    // form submit handler: for nodes and comments, set the uid property
+    // to the current user. We would do this with anything that has a uid
+    // property, but entity_get_property_info() calls it 'author' and it's just
+    // starting to get faffy now.
+    if ($entity_type == 'node' || $entity_type == 'comment') {
+      $values['uid'] = $GLOBALS['user']->uid;
+    }
+
+    $entity = entity_create($entity_type, $values);
+
+    // Add our own property to the entity, where we keep track of the properties
+    // that are exposed as form elements in the view. This is how we will
+    // determine whether or not to save it when the form is submitted.
+    $entity->editableviews_exposed_fields = array();
+
+    // Add our own property to specify whether this needs to be saved or not.
+    // @see editableviews_entity_form_submit_build_values()
+    $entity->editableviews_needs_save = FALSE;
+
+    return $entity;
+  }
+
+  /**
+   * Sets the properties so that new entities connect to existing ones.
+   *
+   * For a forward relationship, the existing entity must know it has to point
+   * to the new entity once it has been saved.
+   * For a reverse relationship, the new entity must have the right property set
+   * (e.g. an entityreference field) so that it point back to the existing
+   * entity.
+   *
+   * @param $result_entities
+   *  The array of result entities from the style plugin. Passed by reference
+   *  so the entities can be altered. (TODO: is this actually needed??)
+   * @param $results_coordinates
+   *  The combined coordinates array, containing both the forward and reverse
+   *  lookups for entities and results.
+   *  @see editableviews_plugin_style_row_edit_table::get_form() for details.
+   * @param $edit_field_handlers_grouped
+   *  The edit field handlers, grouped by relationship handler ID.
+   */
+  function connect_new_entities(&$result_entities, $results_coordinates, $edit_field_handlers_grouped) {
+    $relationship_handlers = $this->plugin->display->handler->get_handlers('relationship');
+
+    //dsm($edit_field_handlers_grouped);
+    //dsm($result_entities);
+
+    foreach (array_keys($result_entities) as $entity_type) {
+      foreach ($result_entities[$entity_type] as $entity_id => $entity) {
+        // New entities have a non-numeric fake id we just gave them.
+        if (!is_numeric($entity_id)) {
+          // Get the views coordinates for this entity.
+          list($relationship_id, $index) = $results_coordinates['entities_to_results'][$entity_type][$entity_id];
+
+          $relationship_handler = $relationship_handlers[$relationship_id];
+          //dsm($relationship_handler);
+
+          // Get the relationship that the relationship is on, so we can then
+          // get the entity for that relationship.
+          if (isset($relationship_handler->relationship)) {
+            $relationship_relationship = $relationship_handler->relationship;
+          }
+          else {
+            $relationship_relationship = $this->plugin->view->base_table;
+          }
+
+          // Only act if the new entity's relationship has editable fields:
+          // otherwise it's just an empty bunch of table cells, and there's
+          // nothing to connect to or from.
+          if (count($edit_field_handlers_grouped[$relationship_relationship]) == 0) {
+            continue;
+          }
+
+          if ($relationship_handler->definition['editableviews_direction'] == 'forward') {
+            // Get the entity on our relationship's relationship -- same
+            // as for reverse.
+            // Get the entity out of the imaginary Views grid that is on the same
+            // row as us, and in the $relationship_relationship relationship...
+            list($referring_entity_type, $referring_entity_id) = $results_coordinates['results_to_entities'][$relationship_relationship][$index];
+            $referring_entity = $result_entities[$referring_entity_type][$referring_entity_id];
+
+            // Store this entity's details on the current, new entity, so that
+            // when (and if!) we save it, we can go and make the referring
+            // entity point to it.
+            $entity->editableviews_future_reference = array(
+              'entity_type' => $referring_entity_type,
+              'entity_id' => $referring_entity_id,
+              'field_name' => $relationship_handler->definition['field_name'],
+            );
+          }
+          else {
+            // Would be nice to factor this out to a helper method, say
+            // '$this->new_entity_set_reverse_connection()' but we'd need to
+            // pass so many variables it's probably just as faffy.
+
+            // Get the entity out of the imaginary Views grid that is on the same
+            // row as us, and in the $relationship_relationship relationship...
+            list($referred_entity_type, $referred_entity_id) = $results_coordinates['results_to_entities'][$relationship_relationship][$index];
+            $referred_entity = $result_entities[$referred_entity_type][$referred_entity_id];
+
+            // From here on, this is just reverse relationships!
+            $wrapper = entity_metadata_wrapper($entity_type, $entity);
+
+            // This is what we need to set on the new entity in a reverse relationship.
+            $relationship_field_name = $relationship_handler->definition['field_name'];
+            // Make the new entity point to the entity on its relationship's
+            // relationship.
+            $wrapper->{$relationship_field_name}->set($referred_entity_id);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Get editable field handlers grouped by relationship id.
+   */
+  function get_editable_field_handlers_grouped() {
+    $editable_field_handlers = $this->plugin->get_edit_field_handlers();
+
+    $editable_field_handlers_grouped = array();
+    foreach ($editable_field_handlers as $field_handler_id => $field_handler) {
+      //dsm($field_handler, '$field_handler');
+      $relationship_id = $field_handler->options['relationship'];
+      if ($relationship_id == 'none') {
+        // TODO: tidy up this WTF!
+        $relationship_id = 'base';
+      }
+
+      $editable_field_handlers_grouped[$relationship_id][$field_handler_id] = $field_handler;
+    }
+
+    return $editable_field_handlers_grouped;
+  }
+
+}

--- a/docroot/sites/all/modules/contrib/editableviews/handlers/editableviews_handler_field_entity_metadata_property.inc
+++ b/docroot/sites/all/modules/contrib/editableviews/handlers/editableviews_handler_field_entity_metadata_property.inc
@@ -1,0 +1,316 @@
+<?php
+
+/**
+ * Field handler for editing an entity metadata property.
+ *
+ * This allows editing of Entity API metadata properties, as defined in
+ * hook_entity_property_info(). To qualify, an entity property must have its
+ * 'setter callback' info property defined.
+ */
+class editableviews_handler_field_entity_metadata_property extends views_handler_field {
+
+  /**
+   * Boolean to indicate to the style plugin that this field is editable.
+   */
+  public $editable = TRUE;
+
+  function option_definition() {
+    $options = parent::option_definition();
+
+    $options['property'] = array('default' => NULL);
+    $options['form_use_label'] = array('default' => FALSE);
+    $options['reverse_boolean'] = array('default' => FALSE);
+
+    return $options;
+  }
+
+  function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    $table_data = views_fetch_data($this->table);
+    $entity_info = entity_get_info($table_data['table']['entity type']);
+    $entity_property_info = entity_get_property_info($table_data['table']['entity type']);
+
+    // Create an array of grouped options.
+    $options = array();
+
+    // Common properties.
+    $label_common = t('Common');
+    $options[$label_common] = array();
+    if (isset($entity_info['entity keys']['bundle'])) {
+      // Entity API makes the bundle entity key settable, presumably for
+      // creating new entities. That's really not going to fly here.
+      // (No need to check it exists before we attempt to unset it.)
+      unset($entity_property_info['properties'][$entity_info['entity keys']['bundle']]);
+    }
+
+    foreach ($entity_property_info['properties'] as $property_name => $property_info) {
+      if (empty($property_info['setter callback'])) {
+        // We can't do anything with a property that has no information about
+        // how to set it.
+        continue;
+      }
+
+      if (!empty($property_info['field'])) {
+        // FieldAPI fields have their own handler that does a far better job
+        // (with widgets, etc) than this can do.
+        continue;
+      }
+
+      $options[$label_common][$property_name] = $property_info['label'];
+    }
+
+    // Bundle-specific properties.
+    foreach ($entity_property_info['bundles'] as $bundle_name => $bundle_info) {
+      $bundle_label = $entity_info['bundles'][$bundle_name]['label'];
+      $options[$bundle_label] = array();
+      foreach ($bundle_info['properties'] as $property_name => $property_info) {
+        if (empty($property_info['setter callback'])) {
+          // We can't do anything with a property that has no information about
+          // how to set it.
+          continue;
+        }
+
+        if (!empty($property_info['field'])) {
+          // FieldAPI fields have their own handler that does a far better job
+          // (with widgets, etc) than this can do.
+          continue;
+        }
+
+        $options[$bundle_label][$property_name] = $property_info['label'];
+      }
+    }
+
+    $form['property'] = array(
+      '#type' => 'select',
+      '#title' => t('Metadata property'),
+      '#options' => $options,
+      '#description' => t('Select the property to edit with this field. (Only properties that define how they may be set on an entity are available. Be sure to ensure the property applies to all entities the View will show.)'),
+      '#default_value' => $this->options['property'],
+      // Views AJAX magic which I don't pretend to understand, which allows a
+      // dependent form element for 'reverse_boolean'.
+      '#ajax' => array(
+        'path' => views_ui_build_form_url($form_state),
+      ),
+      '#submit' => array('views_ui_config_item_form_submit_temporary'),
+      '#executes_submit_callback' => TRUE,
+    );
+
+    $form['form_use_label'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Use handler label for form element'),
+      '#description' => t('Use the label for this handler on the form element, rather than the label set in metadata properties which is not always suited to non-developer consumption.'),
+      '#default_value' => $this->options['form_use_label'],
+    );
+
+    if ($this->options['property']) {
+      $entity_all_property_info = entity_get_all_property_info($table_data['table']['entity type']);
+      $selected_property_info = $entity_all_property_info[$this->options['property']];
+
+      if ($selected_property_info['type'] == 'boolean') {
+        $form['reverse_boolean'] = array(
+          '#type' => 'checkbox',
+          '#title' => t('Reverse checkbox value'),
+          '#description' => t('Reverse the value of the boolean property in the checkbox. Use this for properties which make more sense to the user when inverted.'),
+          '#default_value' => $this->options['reverse_boolean'],
+        );
+      }
+    }
+  }
+
+  /**
+   * Return the name of the entity property this handler controls.
+   */
+  function field_name() {
+    return $this->options['property'];
+  }
+
+  /**
+   * Render the field.
+   *
+   * Override this as otherwise we'd just output the entity ID all the time.
+   *
+   * @param $values
+   *   The values retrieved from the database.
+   */
+  function render($values) {
+    // Don't return anything. We don't know the entity we're on at this point.
+    // TODO: split up insert_form_elements() to do all the joining up of data
+    // before parent::render_fields() is called, and set the entity on the
+    // handlers. This would allow us to output the value of the property here.
+    return '';
+  }
+
+  /**
+   * Add the edit form for the field.
+   */
+  function edit_form($entity_type, $entity, &$element, &$form_state) {
+    // Something weird in Views admin UI causes us to come here (because the
+    // style plugin gets rendered) without the options set on this handler. This
+    // then causes an AJAX error because further down we access a metadata
+    // wrapper with no property. I have no time to go chasing this right now, so
+    // for now, just bail here if we're not properly set up. Doing this appears
+    // to have no adverse or visible side effects.
+    if (empty($this->options['property'])) {
+      return;
+    }
+
+    $wrapper = entity_metadata_wrapper($entity_type, $entity);
+
+    // Get the info for the property we are working with. We only need to get
+    // this once.
+    if (!isset($this->property_info)) {
+      $this->property_info = $wrapper->getPropertyInfo($this->options['property']);
+    }
+
+    if (isset($this->property_info['options list'])) {
+      // Special case: if the property has an 'options list' defined, we can
+      // show a select form element of options.
+      $this->edit_form_element_select($element, $form_state, $wrapper);
+    }
+    else {
+      // The type of form element we add depends on the type of the property.
+      // This is just a best guess.
+      // TODO: add an option to override this?
+      switch ($this->property_info['type']) {
+        case 'boolean':
+          $this->edit_form_element_checkbox($element, $form_state, $wrapper);
+          break;
+        default:
+          $this->edit_form_element_textfield($element, $form_state, $wrapper);
+          break;
+      }
+    }
+
+    // Set the title property.
+    if ($this->options['form_use_label']) {
+      $element[$this->options['property']]['#title'] = $this->options['label'];
+    }
+    else {
+      $element[$this->options['property']]['#title'] = check_plain($this->property_info['label']);
+    }
+  }
+
+  /**
+   * Create a textfield element.
+   *
+   * @param &$element
+   *  The element to alter.
+   * @param &$form_state
+   *  The form state.
+   * @param $wrapper
+   *  The wrapper for the entity whose property is to be shown in the element.
+   */
+  function edit_form_element_textfield(&$element, &$form_state, $wrapper) {
+    // Just do the same thing as node_content_form().
+    $element[$this->options['property']] = array(
+      '#type' => 'textfield',
+      '#required' => !empty($this->property_info['required']),
+      // The value might not be set in the case where we're on a non-required
+      // relationship with empty data. TODO???
+      '#default_value' => $wrapper->{$this->options['property']}->raw(),
+      //'#size' => $this->options['textfield_size'],
+      '#maxlength' => 255,
+    );
+  }
+
+  /**
+   * Create a select element.
+   *
+   * @param &$element
+   *  The element to alter.
+   * @param &$form_state
+   *  The form state.
+   * @param $wrapper
+   *  The wrapper for the entity whose property is to be shown in the element.
+   */
+  function edit_form_element_select(&$element, &$form_state, $wrapper) {
+    // Just do the same thing as node_content_form().
+    $element[$this->options['property']] = array(
+      '#type' => 'select',
+      '#required' => !empty($this->property_info['required']),
+      '#options' => $wrapper->{$this->options['property']}->optionsList(),
+      // The value might not be set in the case where we're on a non-required
+      // relationship with empty data. TODO???
+      '#default_value' => $wrapper->{$this->options['property']}->raw(),
+    );
+  }
+
+  /**
+   * Create a checkbox element.
+   *
+   * @param &$element
+   *  The element to alter.
+   * @param &$form_state
+   *  The form state.
+   * @param $wrapper
+   *  The wrapper for the entity whose property is to be shown in the element.
+   */
+  function edit_form_element_checkbox(&$element, &$form_state, $wrapper) {
+    $default_value = $wrapper->{$this->options['property']}->raw();
+    if ($this->options['reverse_boolean']) {
+      $default_value = !$default_value;
+    }
+
+    $element[$this->options['property']] = array(
+      '#type' => 'checkbox',
+      '#required' => !empty($this->property_info['required']),
+      // The value might not be set in the case where we're on a non-required
+      // relationship with empty data. TODO???
+      '#default_value' => $default_value,
+    );
+  }
+
+  /**
+   * Helper to get the value out of the form element.
+   */
+  function get_element_value($element, $form_state) {
+    // The element's '#parents' property gets us nearly all the way there.
+    $parents = $element['#parents'];
+    $parents[] = $this->options['property'];
+
+    $value = drupal_array_get_nested_value($form_state['values'], $parents);
+
+    return $value;
+  }
+
+  /**
+   * Handle the form validation for this field's form element.
+   */
+  function edit_form_validate($entity_type, $entity, &$element, &$form_state) {
+    // Wrappers don't have a way of testing the waters to validate, but we can
+    // attempt to set the property and catch an exception.
+    try {
+      // Get the value out of the form state.
+      $value = $this->get_element_value($element, $form_state);
+      if ($this->options['reverse_boolean']) {
+        $value = !$value;
+      }
+
+      // Set it on the wrapper, and stand back!
+      $wrapper = entity_metadata_wrapper($entity_type, $entity);
+      $wrapper->{$this->options['property']}->set($value);
+    }
+    catch (EntityMetadataWrapperException $e) {
+      // TODO: the exception message from Entity API is not that end-user-friendly.
+      form_error($element[$this->options['property']], $e->getMessage());
+    }
+  }
+
+  /**
+   * Handle the form submission for this field's form element.
+   */
+  function edit_form_submit($entity_type, $entity, &$element, &$form_state) {
+    // Get the value out of the form state.
+    $value = $this->get_element_value($element, $form_state);
+    if ($this->options['reverse_boolean']) {
+      $value = !$value;
+    }
+
+    // We can set this on the wrapper with inpunity, as the validate step
+    // already caught any exception this might throw.
+    $wrapper = entity_metadata_wrapper($entity_type, $entity);
+    $wrapper->{$this->options['property']}->set($value);
+  }
+
+}

--- a/docroot/sites/all/modules/contrib/editableviews/handlers/editableviews_handler_field_field_edit.inc
+++ b/docroot/sites/all/modules/contrib/editableviews/handlers/editableviews_handler_field_field_edit.inc
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * Field handler for toggling between rendered value and edit form element.
+ *
+ * TODO: figure out a way to show the widget type in the admin summary??
+ */
+class editableviews_handler_field_field_edit extends views_handler_field_field {
+
+  /**
+   * Boolean to indicate to the style plugin that this field is editable.
+   *
+   * We do this here rather than just check the class parentage to allow field
+   * handlers to provide form elements for non-FieldAPI entity properties.
+   */
+  public $editable = TRUE;
+
+  function option_definition() {
+    $options = parent::option_definition();
+
+    // We can't realistically provide a default widget type, because there may
+    // be entities of different bundles in the view result, and therefore
+    // different field instances with different widgets.
+    $options['widget_type'] = array('default' => NULL);
+    $options['suppress_label'] = array('default' => FALSE);
+    $options['suppress_description'] = array('default' => FALSE);
+
+    return $options;
+  }
+
+  function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    $field = field_info_field($this->definition['field_name']);
+    module_load_include('inc', 'field_ui', 'field_ui.admin');
+
+    $widget_options = array(
+      // Banking on there being no widget type called '0', which is a reasonable
+      // assumption to make!
+      0 => t('Default'),
+    );
+    $widget_options += field_ui_widget_type_options($field['type']);
+    $form['widget_type'] = array(
+      '#type' => 'select',
+      '#title' => t('Widget type'),
+      '#options' => $widget_options,
+      '#default_value' => $this->options['widget_type'],
+      '#description' => t("The type of form element you would like to present to the user when editing this field." . ' ' .
+        "'Default' will use the widget from field settings, and may result in different widgets showing if the entities are of different bundles."),
+    );
+
+    $form['suppress_label'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Hide widget label'),
+      '#description' => t('If selected, the label on field widget is hidden. (If the field is required, the * will still show.)'),
+      '#default_value' => $this->options['suppress_label'],
+    );
+
+    $form['suppress_description'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Hide field widget description'),
+      '#description' => t('If selected, the description on field widgets is hidden.'),
+      '#default_value' => $this->options['suppress_description'],
+    );
+  }
+
+  /**
+   * Return the name of the entity property this handler controls.
+   */
+  function field_name() {
+    return $this->definition['field_name'];
+  }
+
+  /**
+   * Add the form element for this handler's field to the form.
+   *
+   * We break this out into the handler to allow other handlers that work with
+   * non-FieldAPI fields (eg node title) to also provide a form element.
+   *
+   * @param $entity_type
+   *  The entity type.
+   * @param $entity
+   *  The entity.
+   * @param &$element
+   *  The partial form, at $form[ENTITY_ID]. This is passed by reference and
+   *  should be altered in place.
+   * @param &$form_state
+   *  The form state.
+   */
+  function edit_form($entity_type, $entity, &$element, &$form_state) {
+    list($entity_id, $vid, $bundle) = entity_extract_ids($entity_type, $entity);
+
+    // TODO: this prevents this method being static. This would mean we could
+    // store class names in the form rather than handler objects, which would
+    // considerably save on form cache size!
+    $field_name = $this->definition['field_name'];
+    $field_instance = field_info_instance($entity_type, $field_name, $bundle);
+
+    // Because a View result can show entities of different bundles, it is
+    // essential that we check the field actually exists on the current entity.
+    // ctools_field_invoke_field() does actually check for this too, but that
+    // only works when it's passed a field name rather than a whole instance.
+    if (empty($field_instance)) {
+      return;
+    }
+
+    // TODO: Faffy to have to keep doing this for the entity in each handler!!!!
+    if (isset($entity->language)) {
+      $langcode = field_valid_language($entity->language);
+    }
+    else {
+      $langcode = field_valid_language(NULL);
+    }
+
+    if (!empty($this->options['suppress_label'])) {
+      $field_instance['label'] = '';
+    }
+    if (!empty($this->options['suppress_description'])) {
+      $field_instance['description'] = '';
+    }
+
+    // Only doctor the widget type if the option is set; otherwise the widget
+    // type set for the entity's bundle will be used.
+    if (!empty($this->options['widget_type'])) {
+      $field_instance['widget']['type'] = $this->options['widget_type'];
+
+      // We also need to set the module for the widget, in case this differs
+      // from the module for the original widget, because this is used to
+      // determine which module's hook_field_widget_form() gets invoked.
+      $widget_info = field_info_widget_types();
+      $widget_info = $widget_info[$this->options['widget_type']];
+      $field_instance['widget']['module'] = $widget_info['module'];
+    }
+
+    // On new entities, force this to not be required, to allow the user to not
+    // create the new entity.
+    // Obviously, problems arise when there are multiple editable fields on
+    // this entity, since the title *is* required if actually creating an
+    // entity!
+    // TODO: consider this thorny problem.
+    if (!empty($entity->is_new)) {
+      $field_instance['required'] = FALSE;
+    }
+
+    // If no language is provided use the default site language.
+    $field_invoke_options = array(
+      'language' => $langcode,
+      'default' => TRUE,
+    );
+
+    $element += (array) ctools_field_invoke_field($field_instance, 'form', $entity_type, $entity, $element, $form_state, $field_invoke_options);
+  }
+
+  /**
+   * Handle the form validation for this field's form element.
+   *
+   * @param $entity_type
+   *  The entity type.
+   * @param $entity
+   *  The entity.
+   * @param &$element
+   *  The partial form, at $form[ENTITY_ID].
+   * @param &$form_state
+   *  The form state.
+   * @param &$errors
+   *  An array of errors, in the same format as expected by
+   *  hook_field_attach_validate().
+   */
+  function edit_form_validate($entity_type, $entity, &$element, &$form_state, &$errors) {
+    list($entity_id, $vid, $bundle) = entity_extract_ids($entity_type, $entity);
+    $field_name = $this->definition['field_name'];
+    $field_instance = field_info_instance($entity_type, $field_name, $bundle);
+
+    // Because a View result can show entities of different bundles, it is
+    // essential that we check the field actually exists on the current entity.
+    // ctools_field_invoke_field() does actually check for this too, but that
+    // only works when it's passed a field name rather than a whole instance.
+    if (empty($field_instance)) {
+      return;
+    }
+
+    // Extract field values from submitted values.
+    // We pass a partial $form array to the Field API hook. This contains at
+    // its base the #parents array, which tells Field API where to look for
+    // the values in $form_state.
+    ctools_field_invoke_field_default($field_instance, 'extract_form_values', $entity_type, $entity, $element, $form_state);
+
+    // Check generic, field-type-agnostic errors first.
+    ctools_field_invoke_field_default($field_instance, 'validate', $entity_type, $entity, $errors);
+    // Check field-type specific errors.
+    ctools_field_invoke_field($field_instance, 'validate', $entity_type, $entity, $errors);
+  }
+
+  /**
+   * Set form validation errors for this field's form element.
+   *
+   * @param $entity_type
+   *  The entity type.
+   * @param $entity
+   *  The entity.
+   * @param &$element
+   *  The partial form, at $form[ENTITY_ID].
+   * @param &$form_state
+   *  The form state.
+   * @param &$errors
+   *  An array of errors, in the same format as expected by
+   *  hook_field_attach_validate().
+   */
+  function edit_form_validate_errors($entity_type, $entity, &$element, &$form_state, &$errors) {
+    list($entity_id, $vid, $bundle) = entity_extract_ids($entity_type, $entity);
+    $field_name = $this->definition['field_name'];
+    $field_instance = field_info_instance($entity_type, $field_name, $bundle);
+
+    // Pass field-level validation errors back to widgets for accurate error
+    // flagging.
+    foreach ($errors as $field_errors) {
+      foreach ($field_errors as $langcode => $errors) {
+        $field_state = field_form_get_state($element['#parents'], $field_name, $langcode, $form_state);
+        $field_state['errors'] = $errors;
+        field_form_set_state($element['#parents'], $field_name, $langcode, $form_state, $field_state);
+      }
+    }
+    ctools_field_invoke_field_default($field_instance, 'form_errors', $entity_type, $entity, $element, $form_state);
+  }
+
+  /**
+   * Handle the form submission for this field's form element.
+   */
+  function edit_form_submit($entity_type, $entity, &$element, &$form_state) {
+    list($entity_id, $vid, $bundle) = entity_extract_ids($entity_type, $entity);
+    $field_name = $this->definition['field_name'];
+    $field_instance = field_info_instance($entity_type, $field_name, $bundle);
+
+    // Because a View result can show entities of different bundles, it is
+    // essential that we check the field actually exists on the current entity.
+    // ctools_field_invoke_field() does actually check for this too, but that
+    // only works when it's passed a field name rather than a whole instance.
+    if (empty($field_instance)) {
+      return;
+    }
+
+    // Extract field values from submitted values.
+    // We pass the partial $form array to the Field API hook. This contains at
+    // its base the #parents array, which tells Field API where to look for
+    // the values in $form_state.
+    ctools_field_invoke_field_default($field_instance, 'extract_form_values', $entity_type, $entity, $element, $form_state);
+
+    ctools_field_invoke_field_default($field_instance, 'submit',              $entity_type, $entity, $element, $form_state);
+  }
+
+}

--- a/docroot/sites/all/modules/contrib/editableviews/handlers/editableviews_handler_field_node_title_edit.inc
+++ b/docroot/sites/all/modules/contrib/editableviews/handlers/editableviews_handler_field_node_title_edit.inc
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Field handler for node title editable field.
+ */
+class editableviews_handler_field_node_title_edit extends views_handler_field_node {
+
+  /**
+   * Boolean to indicate to the style plugin that this field is editable.
+   *
+   * We do this here rather than just check the class parentage to allow field
+   * handlers to provide form elements for non-FieldAPI entity properties.
+   */
+  public $editable = TRUE;
+
+  function option_definition() {
+    $options = parent::option_definition();
+
+    $options['textfield_size'] = array('default' => NULL);
+
+    return $options;
+  }
+
+  function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    $form['textfield_size'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Textfield size'),
+      '#description' => t("The size of the textfield for this form element."),
+      '#default_value' => $this->options['textfield_size'],
+      '#size' => 6,
+    );
+  }
+
+  /**
+   * Return the name of the entity property this handler controls.
+   */
+  function field_name() {
+    return 'title';
+  }
+
+  /**
+   * Return the edit form for the field.
+   */
+  function edit_form($entity_type, $entity, &$element, &$form_state) {
+    // Just do the same thing as node_content_form().
+    $type = node_type_get_type($entity);
+    $element['title'] = array(
+      '#type' => 'textfield',
+      '#title' => check_plain($type->title_label),
+      // This is required on existing entities, but not on new ones to allow
+      // the user to not create the new entity.
+      // Obviously, problems arise when there are multiple editable fields on
+      // this entity, since the title *is* required if actually creating an
+      // entity!
+      // TODO: consider this thorny problem.
+      '#required' => isset($entity->nid),
+      // The title might not be set in the case where we're on a non-required
+      // relationship with empty data.
+      '#default_value' => isset($entity->title) ? $entity->title : '',
+      '#size' => $this->options['textfield_size'],
+      '#maxlength' => 255,
+    );
+  }
+
+  /**
+   * Handle the form validation for this field's form element.
+   */
+  function edit_form_validate() {
+    // Nothing to do.
+  }
+
+  /**
+   * Handle the form submission for this field's form element.
+   */
+  function edit_form_submit($entity_type, $entity, &$element, &$form_state) {
+    $parents = $element['#parents'];
+    $parents[] = 'title';
+
+    // Get the value out of the form state.
+    $value = drupal_array_get_nested_value($form_state['values'], $parents);
+
+    // Set it on the node.
+    $entity->title = $value;
+  }
+
+}

--- a/docroot/sites/all/modules/contrib/editableviews/handlers/editableviews_handler_field_save_button_jump_link.inc
+++ b/docroot/sites/all/modules/contrib/editableviews/handlers/editableviews_handler_field_save_button_jump_link.inc
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Field handler that shows a jump link to the save button.
+ *
+ * This is intended for use on very long views.
+ */
+class editableviews_handler_field_save_button_jump_link extends views_handler_field {
+
+  function option_definition() {
+    $options = parent::option_definition();
+
+    $options['jump_link_text'] = array('default' => t('Jump to save button'));
+
+    return $options;
+  }
+
+  function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    $form['jump_link_text'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Jump link text'),
+      '#default_value' => $this->options['jump_link_text'],
+      '#description' => t("The text to show for the link."),
+    );
+  }
+
+  /**
+   * Called to add the field to a query.
+   */
+  function query() {
+    // Do nothing: fake field.
+  }
+
+  /**
+   * Render the field.
+   *
+   * @param $values
+   *   The values retrieved from the database.
+   */
+  function render($values) {
+    return '<a href="#edit-actions-submit">' . check_plain($this->options['jump_link_text']) . '</a>';
+  }
+
+}

--- a/docroot/sites/all/modules/contrib/editableviews/tests/editableviews.test
+++ b/docroot/sites/all/modules/contrib/editableviews/tests/editableviews.test
@@ -1,0 +1,415 @@
+<?php
+
+/**
+ * @file
+ * Tests for editableviews.module.
+ *
+ * These tests rely on the accompanying feature module, which defines the node
+ * types and view, and thus also on Features module. While this adds a
+ * dependency on another contrib module, having the node types, fields, and
+ * views in Features greatly reduces developer work in creating the components
+ * to test, allows the test cases to focus on what's actually being tested, and
+ * hopefully reduces future maintenance.
+ */
+
+/**
+ * Defines a base class for testing the Editable Views module.
+ */
+class EditableViewsBaseWebTestCase extends DrupalWebTestCase {
+
+  function setUp() {
+    parent::setUp(array('editableviews', 'features', 'entityreference', 'editableviews_test_feature', 'editableviews_test'));
+  }
+
+}
+
+/**
+ * Test simple editable views with no editable fields on relationships.
+ */
+class EditableViewsBasicWebTestCase extends EditableViewsBaseWebTestCase {
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Test simple editable views',
+      'description' => 'Test basic views without relationships.',
+      'group' => 'Editable Views',
+    );
+  }
+
+  /**
+   * Test basic node view 'test_editable_views_node_title'.
+   */
+  function testNodeTitleView() {
+    $first_node_title = $this->randomName();
+    $first_node = $this->drupalCreateNode(array(
+      'title' => $first_node_title,
+      'type'  => 'editable_views_test_node',
+    ));
+    $second_node_title = $this->randomName();
+    $second_node = $this->drupalCreateNode(array(
+      'title' => $second_node_title,
+      'type'  => 'editable_views_test_node',
+    ));
+
+    // Look at the node title editable view.
+    $this->drupalGet('test-editable-views-node-title');
+
+    // Check both nodes are shown in the view form.
+    $first_node_title_element_name = "node[{$first_node->nid}][title]";
+    $this->assertFieldByName($first_node_title_element_name, $first_node_title, t("View shows an edit form for the first node's title."));
+
+    $second_node_title_element_name = "node[{$second_node->nid}][title]";
+    $this->assertFieldByName($second_node_title_element_name, $second_node_title, t("View shows an edit form for the second node's title."));
+
+    // Save the form with changes to both nodes.
+    $edit = array(
+      $first_node_title_element_name  => $this->randomName(),
+      $second_node_title_element_name => $this->randomName(),
+    );
+    $this->drupalPost('test-editable-views-node-title', $edit, t('Save'));
+
+    // Load the nodes again and check their titles have changed.
+    entity_get_controller('node')->resetCache();
+    $first_node   = node_load($first_node->nid);
+    $second_node  = node_load($second_node->nid);
+
+    $this->assertEqual($first_node->title, $edit[$first_node_title_element_name], t("The first node's title has been changed by saving the editable view."));
+    $this->assertEqual($second_node->title, $edit[$second_node_title_element_name], t("The second node's title has been changed by saving the editable view."));
+
+    // Save the form again, with changes to just one node.
+    $edit = array(
+      $first_node_title_element_name  => $this->randomName(),
+    );
+    $second_node_title_old = $second_node->title;
+    $this->drupalPost('test-editable-views-node-title', $edit, t('Save'));
+
+    // Load the nodes again and check their titles.
+    entity_get_controller('node')->resetCache();
+    $first_node   = node_load($first_node->nid);
+    $second_node  = node_load($second_node->nid);
+
+    $this->assertEqual($first_node->title, $edit[$first_node_title_element_name], t("The first node's title has been changed by saving the editable view."));
+    $this->assertEqual($second_node->title, $second_node_title_old, t("The second node's title was not changed when the editable view was saved with no value for it."));
+  }
+
+  /**
+   * Test basic node view 'editable_views_node_fields'.
+   */
+  function testNodeFieldsView() {
+    $first_node_title = $this->randomName();
+    $first_node = $this->drupalCreateNode(array(
+      'title' => $first_node_title,
+      'type'  => 'editable_views_test_node',
+    ));
+    $second_node_title = $this->randomName();
+    $second_node = $this->drupalCreateNode(array(
+      'title' => $second_node_title,
+      'type'  => 'editable_views_test_node',
+    ));
+
+    // The fields are defined in the feature module.
+    $field_names = array(
+      'field_test_editable_text',
+      'field_test_editable_options',
+    );
+    // An array of form element names, keyed first by node id, and then by
+    // field name.
+    $field_element_names = array(
+      $first_node->nid => array(
+        'field_test_editable_text'    => "node[{$first_node->nid}][field_test_editable_text][und][0][value]",
+        'field_test_editable_options' => "node[{$first_node->nid}][field_test_editable_options][und]",
+      ),
+      $second_node->nid => array(
+        'field_test_editable_text'    => "node[{$second_node->nid}][field_test_editable_text][und][0][value]",
+        'field_test_editable_options' => "node[{$second_node->nid}][field_test_editable_options][und]",
+      ),
+    );
+
+    // Look at the node title editable view.
+    $this->drupalGet('test-editable-views-node-fields');
+
+    // Check the field editable elements are shown in the view form.
+    foreach ($field_names as $field_name) {
+      $this->assertFieldByName($field_element_names[$first_node->nid][$field_name], '', t("View shows an edit form for the first node's $field_name field."));
+
+      $this->assertFieldByName($field_element_names[$second_node->nid][$field_name], '', t("View shows an edit form for the second node's $field_name field."));
+    }
+
+    // Save the form with changes to the first node, but with a field value on
+    // the second node that will fail validation, because
+    // editableviews_test_field_attach_validate() will reject 'banana'.
+     // Ensure this string is definitely NOT 'banana'.
+    $new_value_field_test_editable_text     = $this->randomString(8);
+    $new_value_field_test_editable_options  = 1;
+    $edit = array(
+      "node[{$first_node->nid}][field_test_editable_text][und][0][value]"   => $new_value_field_test_editable_text,
+      "node[{$first_node->nid}][field_test_editable_options][und]"          => $new_value_field_test_editable_options,
+      "node[{$second_node->nid}][field_test_editable_text][und][0][value]"  => 'banana',
+    );
+    $this->drupalPost('test-editable-views-node-fields', $edit, t('Save'));
+
+    // Form validation should fail...
+    $this->assertText('Text may not be "banana" (error 1).', "The form error message was shown for the editable text field.");
+    // ...but only once.
+    $this->assertNoText('Text may not be "banana" (error 2).', "The form error message is shown only once.");
+
+    // Neither node should be saved.
+    entity_get_controller('node')->resetCache();
+    $first_node = node_load($first_node->nid);
+    $first_node_wrapper = entity_metadata_wrapper('node', $first_node);
+
+    $this->assertNotEqual($first_node_wrapper->field_test_editable_text->value(), $new_value_field_test_editable_text, t("The node's field value was not set to the new value."));
+    $this->assertNotEqual($first_node_wrapper->field_test_editable_options->value(), $new_value_field_test_editable_options, t("The node's field value was not set to the new value."));
+
+    $second_node = node_load($second_node->nid);
+    $second_node_wrapper = entity_metadata_wrapper('node', $second_node);
+
+    $this->assertNotEqual($first_node_wrapper->field_test_editable_text->value(), 'banana', t("The node's field value was not set to the new value."));
+
+    // Save the form again, this time without a bad value.
+    $edit = array(
+      "node[{$first_node->nid}][field_test_editable_text][und][0][value]"   => $new_value_field_test_editable_text,
+      "node[{$first_node->nid}][field_test_editable_options][und]"          => $new_value_field_test_editable_options,
+    );
+    $this->drupalPost('test-editable-views-node-fields', $edit, t('Save'));
+
+    // The first node should be saved and have new data in its fields.
+    entity_get_controller('node')->resetCache();
+    $first_node = node_load($first_node->nid);
+    $first_node_wrapper = entity_metadata_wrapper('node', $first_node);
+
+    $this->assertEqual($first_node_wrapper->field_test_editable_text->value(), $new_value_field_test_editable_text, t("The node's field value is set to the new value by saving the view."));
+    $this->assertEqual($first_node_wrapper->field_test_editable_options->value(), $new_value_field_test_editable_options, t("The node's field value is set to the new value by saving the view."));
+  }
+
+  /**
+   * Test basic node view 'test_editable_views_node_properties'.
+   */
+  function testNodePropertiesView() {
+    $first_node_title = $this->randomName();
+    $first_node = $this->drupalCreateNode(array(
+      'title' => $first_node_title,
+      'type'  => 'editable_views_test_node',
+    ));
+    $second_node_title = $this->randomName();
+    $second_node = $this->drupalCreateNode(array(
+      'title' => $second_node_title,
+      'type'  => 'editable_views_test_node',
+    ));
+
+    $property_names = array(
+      'status',
+      'promote',
+      'sticky',
+    );
+
+    // An array of form element names, keyed first by node id, and then by
+    // property name.
+    $editable_element_names = array(
+      $first_node->nid => array(
+        'status'    => "node[{$first_node->nid}][status]",
+        'promote'   => "node[{$first_node->nid}][promote]",
+        'sticky'    => "node[{$first_node->nid}][sticky]",
+      ),
+      $second_node->nid => array(
+        'status'    => "node[{$second_node->nid}][status]",
+        'promote'   => "node[{$second_node->nid}][promote]",
+        'sticky'    => "node[{$second_node->nid}][sticky]",
+      ),
+    );
+
+    // Look at the node properties editable view.
+    $this->drupalGet('test-editable-views-node-properties');
+
+    // Check the field editable elements are shown in the view form.
+    foreach ($property_names as $property_name) {
+      $this->assertFieldByName($editable_element_names[$first_node->nid][$property_name], NULL, t("View shows an edit form for the first node's $property_name field."));
+
+      $this->assertFieldByName($editable_element_names[$second_node->nid][$property_name], NULL, t("View shows an edit form for the second node's $property_name field."));
+    }
+
+    // Save changes to the first node's properties.
+    $edit = array(
+      "node[{$first_node->nid}][status]"  => 0,
+      "node[{$first_node->nid}][promote]" => 1,
+      "node[{$first_node->nid}][sticky]"  => 1,
+    );
+    $this->drupalPost('test-editable-views-node-properties', $edit, t('Save'));
+
+    entity_get_controller('node')->resetCache();
+    $first_node = node_load($first_node->nid);
+
+    $this->assertEqual($first_node->status, FALSE, t("The node's 'status' property is set to the new value by saving the view."));
+    $this->assertEqual($first_node->promote, TRUE, t("The node's 'status' property is set to the new value by saving the view."));
+    $this->assertEqual($first_node->sticky, TRUE, t("The node's 'status' property is set to the new value by saving the view."));
+  }
+
+}
+
+/**
+ * Test editable views with editable fields on relationships.
+ */
+class EditableViewsEntityReferenceWebTestCase extends EditableViewsBaseWebTestCase {
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Test editable views with relationships',
+      'description' => 'Test editable views with editable fields on relationships.',
+      'group' => 'Editable Views',
+    );
+  }
+
+  /**
+   * Test node view 'test_editable_views_node_referenced_backwards_title'.
+   *
+   * Contains a relationship to another node type via a backwards reference.
+   */
+  function testNodeTitleBackwardsRelationshipView() {
+    // We prefix the node titles to force the order of items in the View to be
+    // predictable. Otherwise, we can't reliably (easily!) test the presence of
+    // form elements for the empty nodes.
+    $first_node_title = 'a' . $this->randomName();
+    $first_node = $this->drupalCreateNode(array(
+      'title' => $first_node_title,
+      'type'  => 'editable_views_test_node',
+    ));
+    $second_node_title = 'z' . $this->randomName();
+    $second_node = $this->drupalCreateNode(array(
+      'title' => $second_node_title,
+      'type'  => 'editable_views_test_node',
+    ));
+    $first_pointer_node_title = $this->randomName();
+    $first_pointer_node = $this->drupalCreateNode(array(
+      'title' => $first_pointer_node_title,
+      'type'  => 'editable_views_test_referencing',
+      'field_test_node_reference' => array(LANGUAGE_NONE => array(array('target_id' => $first_node->nid))),
+    ));
+
+    // Look at the editable view.
+    $this->drupalGet('test_editable_views_node_referenced_backwards_title');
+
+    // Check there are form elements for all three nodes' titles as well as the
+    // empty node.
+    $first_node_title_element_name = "node[{$first_node->nid}][title]";
+    $this->assertFieldByName($first_node_title_element_name, $first_node_title, t("View shows an edit form for the first node's title."));
+
+    $second_node_title_element_name = "node[{$second_node->nid}][title]";
+    $this->assertFieldByName($second_node_title_element_name, $second_node_title, t("View shows an edit form for the second node's title."));
+
+    $first_pointer_node_title_element_name = "node[{$first_pointer_node->nid}][title]";
+    $this->assertFieldByName($first_pointer_node_title_element_name, $first_pointer_node_title, t("View shows an edit form for the first pointer node's title."));
+
+    // The empty node is forced to be in the second row, by the prefixes on the
+    // node titles.
+    $empty_node_title_element_name = "node[reverse_field_test_node_reference_node:1][title]";
+    $this->assertFieldByName($empty_node_title_element_name, '', t("View shows an edit form with an empty value for the empty node."));
+
+    // Change the titles of the referencing nodes, i.e., the second field in the
+    // view. This will create a new node.
+    $edit = array(
+      $first_pointer_node_title_element_name  => $this->randomName(),
+      $empty_node_title_element_name          => $this->randomName(),
+    );
+    $this->drupalPost('test_editable_views_node_referenced_backwards_title', $edit, t('Save'));
+
+    // Check the referencing node's title is changed.
+    entity_get_controller('node')->resetCache();
+    $first_pointer_node = node_load($first_pointer_node->nid);
+    $this->assertEqual($first_pointer_node->title, $edit[$first_pointer_node_title_element_name], t("The referencing node's title has been changed by saving the editable view."));
+
+    // Check a new node was created, referencing the second node.
+    $query = new EntityFieldQuery();
+    $entities = $query->entityCondition('entity_type', 'node')
+      ->propertyCondition('type', 'editable_views_test_referencing')
+      ->propertyCondition('title', $edit[$empty_node_title_element_name])
+      ->execute();
+
+    $this->assertFalse(empty($entities['node']), t("A new referencing node has been created."));
+
+    $second_pointer_node = node_load(array_shift(array_keys($entities['node'])));
+
+    $this->assertEqual($second_pointer_node->title, $edit[$empty_node_title_element_name], t("The second referencing node's title has been set by saving the editable view."));
+
+    // Check it points to the second node.
+    $second_pointer_node_wrapper = entity_metadata_wrapper('node', $second_pointer_node);
+    $this->assertEqual($second_pointer_node_wrapper->field_test_node_reference->raw(), $second_node->nid, t("The second referencing node points to the second node."));
+  }
+
+  /**
+   * Test node view 'test_editable_views_node_referenced_forwards_title'.
+   *
+   * Contains a relationship to another node type via a forwards reference.
+   */
+  function testNodeTitleForwardsRelationshipView() {
+    // We prefix the node titles to force the order of items in the View to be
+    // predictable. Otherwise, we can't reliably (easily!) test the presence of
+    // form elements for the empty nodes.
+    $first_pointed_node_title = $this->randomName();
+    $first_pointed_node = $this->drupalCreateNode(array(
+      'title' => $first_pointed_node_title,
+      'type'  => 'editable_views_test_node',
+    ));
+    $first_node_title = 'a' . $this->randomName();
+    $first_node = $this->drupalCreateNode(array(
+      'title' => $first_node_title,
+      'type'  => 'editable_views_test_referencing',
+      'field_test_node_reference' => array(LANGUAGE_NONE => array(array('target_id' => $first_pointed_node->nid))),
+    ));
+    $second_node_title = 'z' . $this->randomName();
+    $second_node = $this->drupalCreateNode(array(
+      'title' => $second_node_title,
+      'type'  => 'editable_views_test_referencing',
+    ));
+
+    // Look at the editable view.
+    $this->drupalGet('test_editable_views_node_referenced_forwards_title');
+
+    // Check there are form elements for all three nodes' titles as well as the
+    // empty node.
+    $first_node_title_element_name = "node[{$first_node->nid}][title]";
+    $this->assertFieldByName($first_node_title_element_name, $first_node_title, t("View shows an edit form for the first node's title."));
+
+    $second_node_title_element_name = "node[{$second_node->nid}][title]";
+    $this->assertFieldByName($second_node_title_element_name, $second_node_title, t("View shows an edit form for the second node's title."));
+
+    $first_pointed_node_title_element_name = "node[{$first_pointed_node->nid}][title]";
+    $this->assertFieldByName($first_pointed_node_title_element_name, $first_pointed_node_title, t("View shows an edit form for the first pointed node's title."));
+
+    // The empty node is forced to be in the second row, by the prefixes on the
+    // node titles.
+    $empty_node_title_element_name = "node[field_test_node_reference_target_id:1][title]";
+    $this->assertFieldByName($empty_node_title_element_name, '', t("View shows an edit form with an empty value for the empty node."));
+
+    // Change the titles of the referenced nodes, i.e., the second field in the
+    // view. This will create a new node.
+    $edit = array(
+      $first_pointed_node_title_element_name  => $this->randomName(),
+      $empty_node_title_element_name          => $this->randomName(),
+    );
+    $this->drupalPost('test_editable_views_node_referenced_forwards_title', $edit, t('Save'));
+
+    // Check the referenced node's title is changed.
+    entity_get_controller('node')->resetCache();
+    $first_pointed_node = node_load($first_pointed_node->nid);
+    $this->assertEqual($first_pointed_node->title, $edit[$first_pointed_node_title_element_name], t("The referenced node's title has been changed by saving the editable view."));
+
+    // Check a new node was created.
+    $query = new EntityFieldQuery();
+    $entities = $query->entityCondition('entity_type', 'node')
+      ->propertyCondition('type', 'editable_views_test_node')
+      ->propertyCondition('title', $edit[$empty_node_title_element_name])
+      ->execute();
+
+    $this->assertFalse(empty($entities['node']), t("A new referenced node has been created."));
+
+    $second_pointed_node = node_load(array_shift(array_keys($entities['node'])));
+
+    $this->assertEqual($second_pointed_node->title, $edit[$empty_node_title_element_name], t("The second referenced node's title has been set by saving the editable view."));
+
+    // Check the second node points to it.
+    $second_node = node_load($second_node->nid);
+    $second_node_wrapper = entity_metadata_wrapper('node', $second_node);
+    $this->assertEqual($second_node_wrapper->field_test_node_reference->raw(), $second_pointed_node->nid, t("The second node points to the new second referenced node."));
+  }
+
+}

--- a/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test/editableviews_test.info
+++ b/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test/editableviews_test.info
@@ -1,0 +1,12 @@
+name = Editable Views Test
+description = Test module for Editable Views
+core = 7.x
+hidden = TRUE
+dependencies[] = editableviews
+
+; Information added by Drupal.org packaging script on 2015-07-28
+version = "7.x-1.0-beta10"
+core = "7.x"
+project = "editableviews"
+datestamp = "1438114140"
+

--- a/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test/editableviews_test.module
+++ b/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test/editableviews_test.module
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file editableviews_test.module
+ * Test module for Editable Views.
+ */
+
+/**
+ * Implements hook_field_attach_validate().
+ *
+ * Fails validation for the entity if the field 'field_test_editable_text' has
+ * the value 'banana'.
+ */
+function editableviews_test_field_attach_validate($entity_type, $entity, &$errors) {
+  // Keep a count of how many errors we record, so each error message is unique
+  // and can be checked by assertText() / assertNoText().
+  static $error_count = 0;
+
+  $items = field_get_items($entity_type, $entity, 'field_test_editable_text');
+  $field_value = $items[0]['value'];
+
+  if ($field_value == 'banana') {
+    $error_count++;
+
+    $errors['field_test_editable_text'][LANGUAGE_NONE][0][] = array(
+      'error' => 'error',
+      'message' => t('Text may not be "banana" (error !count).', array(
+        '!count' => $error_count,
+      )),
+    );
+  }
+}

--- a/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test_feature/editableviews_test_feature.features.field_base.inc
+++ b/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test_feature/editableviews_test_feature.features.field_base.inc
@@ -1,0 +1,117 @@
+<?php
+/**
+ * @file
+ * editableviews_test_feature.features.field_base.inc
+ */
+
+/**
+ * Implements hook_field_default_field_bases().
+ */
+function editableviews_test_feature_field_default_field_bases() {
+  $field_bases = array();
+
+  // Exported field_base: 'field_test_editable_options'
+  $field_bases['field_test_editable_options'] = array(
+    'active' => 1,
+    'cardinality' => 1,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'field_test_editable_options',
+    'foreign keys' => array(),
+    'indexes' => array(
+      'value' => array(
+        0 => 'value',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'list',
+    'settings' => array(
+      'allowed_values' => array(
+        1 => 'One',
+        2 => 'Two',
+        3 => 'Three',
+      ),
+      'allowed_values_function' => '',
+    ),
+    'translatable' => 0,
+    'type' => 'list_text',
+  );
+
+  // Exported field_base: 'field_test_editable_text'
+  $field_bases['field_test_editable_text'] = array(
+    'active' => 1,
+    'cardinality' => 1,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'field_test_editable_text',
+    'foreign keys' => array(
+      'format' => array(
+        'columns' => array(
+          'format' => 'format',
+        ),
+        'table' => 'filter_format',
+      ),
+    ),
+    'indexes' => array(
+      'format' => array(
+        0 => 'format',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'text',
+    'settings' => array(
+      'max_length' => 255,
+    ),
+    'translatable' => 0,
+    'type' => 'text',
+  );
+
+  // Exported field_base: 'field_test_node_reference'
+  $field_bases['field_test_node_reference'] = array(
+    'active' => 1,
+    'cardinality' => 1,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'field_test_node_reference',
+    'foreign keys' => array(
+      'node' => array(
+        'columns' => array(
+          'target_id' => 'nid',
+        ),
+        'table' => 'node',
+      ),
+    ),
+    'indexes' => array(
+      'target_id' => array(
+        0 => 'target_id',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'entityreference',
+    'settings' => array(
+      'handler' => 'base',
+      'handler_settings' => array(
+        'behaviors' => array(
+          'views-select-list' => array(
+            'status' => 0,
+          ),
+        ),
+        'sort' => array(
+          'direction' => 'ASC',
+          'field' => 'body:value',
+          'property' => 'nid',
+          'type' => 'none',
+        ),
+        'target_bundles' => array(
+          'editable_views_test_node' => 'editable_views_test_node',
+        ),
+      ),
+      'handler_submit' => 'Change handler',
+      'target_type' => 'node',
+    ),
+    'translatable' => 0,
+    'type' => 'entityreference',
+  );
+
+  return $field_bases;
+}

--- a/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test_feature/editableviews_test_feature.features.field_instance.inc
+++ b/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test_feature/editableviews_test_feature.features.field_instance.inc
@@ -1,0 +1,140 @@
+<?php
+/**
+ * @file
+ * editableviews_test_feature.features.field_instance.inc
+ */
+
+/**
+ * Implements hook_field_default_field_instances().
+ */
+function editableviews_test_feature_field_default_field_instances() {
+  $field_instances = array();
+
+  // Exported field_instance: 'node-editable_views_test_node-field_test_editable_options'
+  $field_instances['node-editable_views_test_node-field_test_editable_options'] = array(
+    'bundle' => 'editable_views_test_node',
+    'default_value' => NULL,
+    'deleted' => 0,
+    'description' => '',
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'module' => 'list',
+        'settings' => array(),
+        'type' => 'list_default',
+        'weight' => 2,
+      ),
+      'teaser' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+    ),
+    'entity_type' => 'node',
+    'field_name' => 'field_test_editable_options',
+    'label' => 'Test editable options',
+    'required' => 0,
+    'settings' => array(
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'active' => 1,
+      'module' => 'options',
+      'settings' => array(),
+      'type' => 'options_buttons',
+      'weight' => 2,
+    ),
+  );
+
+  // Exported field_instance: 'node-editable_views_test_node-field_test_editable_text'
+  $field_instances['node-editable_views_test_node-field_test_editable_text'] = array(
+    'bundle' => 'editable_views_test_node',
+    'default_value' => NULL,
+    'deleted' => 0,
+    'description' => '',
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'module' => 'text',
+        'settings' => array(),
+        'type' => 'text_default',
+        'weight' => 1,
+      ),
+      'teaser' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+    ),
+    'entity_type' => 'node',
+    'field_name' => 'field_test_editable_text',
+    'label' => 'Test editable text',
+    'required' => 0,
+    'settings' => array(
+      'text_processing' => 0,
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'active' => 1,
+      'module' => 'text',
+      'settings' => array(
+        'size' => 60,
+      ),
+      'type' => 'text_textfield',
+      'weight' => 1,
+    ),
+  );
+
+  // Exported field_instance: 'node-editable_views_test_referencing-field_test_node_reference'
+  $field_instances['node-editable_views_test_referencing-field_test_node_reference'] = array(
+    'bundle' => 'editable_views_test_referencing',
+    'default_value' => NULL,
+    'deleted' => 0,
+    'description' => '',
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'module' => 'entityreference',
+        'settings' => array(
+          'link' => FALSE,
+        ),
+        'type' => 'entityreference_label',
+        'weight' => 1,
+      ),
+      'teaser' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+    ),
+    'entity_type' => 'node',
+    'field_name' => 'field_test_node_reference',
+    'label' => 'Test node reference',
+    'options_limit' => 0,
+    'options_limit_fields' => array(
+      'body' => 0,
+    ),
+    'required' => 0,
+    'settings' => array(
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'active' => 1,
+      'module' => 'options',
+      'settings' => array(),
+      'type' => 'options_buttons',
+      'weight' => -3,
+    ),
+  );
+
+  // Translatables
+  // Included for use with string extractors like potx.
+  t('Test editable options');
+  t('Test editable text');
+  t('Test node reference');
+
+  return $field_instances;
+}

--- a/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test_feature/editableviews_test_feature.features.inc
+++ b/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test_feature/editableviews_test_feature.features.inc
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @file
+ * editableviews_test_feature.features.inc
+ */
+
+/**
+ * Implements hook_views_api().
+ */
+function editableviews_test_feature_views_api($module = NULL, $api = NULL) {
+  return array("api" => "3.0");
+}
+
+/**
+ * Implements hook_node_info().
+ */
+function editableviews_test_feature_node_info() {
+  $items = array(
+    'editable_views_test_node' => array(
+      'name' => t('Editable Views test node'),
+      'base' => 'node_content',
+      'description' => t('Test node type for Editable Views testing.'),
+      'has_title' => '1',
+      'title_label' => t('Title'),
+      'help' => '',
+    ),
+    'editable_views_test_referencing' => array(
+      'name' => t('Editable Views test referencing'),
+      'base' => 'node_content',
+      'description' => t('References the basic test node via an entityreference field.'),
+      'has_title' => '1',
+      'title_label' => t('Title'),
+      'help' => '',
+    ),
+  );
+  return $items;
+}

--- a/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test_feature/editableviews_test_feature.info
+++ b/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test_feature/editableviews_test_feature.info
@@ -1,0 +1,37 @@
+name = Editable Views Test Feature
+description = Components required for tests for Editable Views.
+core = 7.x
+package = Features
+hidden = TRUE
+dependencies[] = ctools
+dependencies[] = editableviews
+dependencies[] = entityreference
+dependencies[] = features
+dependencies[] = field_sql_storage
+dependencies[] = list
+dependencies[] = node
+dependencies[] = options
+dependencies[] = text
+dependencies[] = views
+features[ctools][] = views:views_default:3.0
+features[features_api][] = api:2
+features[field_base][] = field_test_editable_options
+features[field_base][] = field_test_editable_text
+features[field_base][] = field_test_node_reference
+features[field_instance][] = node-editable_views_test_node-field_test_editable_options
+features[field_instance][] = node-editable_views_test_node-field_test_editable_text
+features[field_instance][] = node-editable_views_test_referencing-field_test_node_reference
+features[node][] = editable_views_test_node
+features[node][] = editable_views_test_referencing
+features[views_view][] = test_editable_views_node_fields
+features[views_view][] = test_editable_views_node_properties
+features[views_view][] = test_editable_views_node_referenced_backwards_title
+features[views_view][] = test_editable_views_node_referenced_forwards_title
+features[views_view][] = test_editable_views_node_title
+
+; Information added by Drupal.org packaging script on 2015-07-28
+version = "7.x-1.0-beta10"
+core = "7.x"
+project = "editableviews"
+datestamp = "1438114140"
+

--- a/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test_feature/editableviews_test_feature.module
+++ b/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test_feature/editableviews_test_feature.module
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @file
+ * Code for the editableviews_test_feature feature.
+ */
+
+include_once 'editableviews_test_feature.features.inc';

--- a/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test_feature/editableviews_test_feature.views_default.inc
+++ b/docroot/sites/all/modules/contrib/editableviews/tests/editableviews_test_feature/editableviews_test_feature.views_default.inc
@@ -1,0 +1,359 @@
+<?php
+/**
+ * @file
+ * editableviews_test_feature.views_default.inc
+ */
+
+/**
+ * Implements hook_views_default_views().
+ */
+function editableviews_test_feature_views_default_views() {
+  $export = array();
+
+  $view = new view();
+  $view->name = 'test_editable_views_node_fields';
+  $view->description = '';
+  $view->tag = 'default';
+  $view->base_table = 'node';
+  $view->human_name = 'Test editable views node fields';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Test editable views node title';
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'some';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+  $handler->display->display_options['style_plugin'] = 'editableviews_table';
+  /* Field: Content: Test editable text (editable) */
+  $handler->display->display_options['fields']['field_test_editable_text_editable']['id'] = 'field_test_editable_text_editable';
+  $handler->display->display_options['fields']['field_test_editable_text_editable']['table'] = 'field_data_field_test_editable_text';
+  $handler->display->display_options['fields']['field_test_editable_text_editable']['field'] = 'field_test_editable_text_editable';
+  $handler->display->display_options['fields']['field_test_editable_text_editable']['widget_type'] = '0';
+  $handler->display->display_options['fields']['field_test_editable_text_editable']['suppress_label'] = 0;
+  $handler->display->display_options['fields']['field_test_editable_text_editable']['suppress_description'] = 0;
+  /* Field: Content: Test editable options (editable) */
+  $handler->display->display_options['fields']['field_test_editable_options_editable']['id'] = 'field_test_editable_options_editable';
+  $handler->display->display_options['fields']['field_test_editable_options_editable']['table'] = 'field_data_field_test_editable_options';
+  $handler->display->display_options['fields']['field_test_editable_options_editable']['field'] = 'field_test_editable_options_editable';
+  $handler->display->display_options['fields']['field_test_editable_options_editable']['widget_type'] = '0';
+  $handler->display->display_options['fields']['field_test_editable_options_editable']['suppress_label'] = 0;
+  $handler->display->display_options['fields']['field_test_editable_options_editable']['suppress_description'] = 0;
+  /* Sort criterion: Content: Post date */
+  $handler->display->display_options['sorts']['created']['id'] = 'created';
+  $handler->display->display_options['sorts']['created']['table'] = 'node';
+  $handler->display->display_options['sorts']['created']['field'] = 'created';
+  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'editable_views_test_node' => 'editable_views_test_node',
+  );
+
+  /* Display: Page */
+  $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['path'] = 'test-editable-views-node-fields';
+  $export['test_editable_views_node_fields'] = $view;
+
+  $view = new view();
+  $view->name = 'test_editable_views_node_properties';
+  $view->description = '';
+  $view->tag = 'default';
+  $view->base_table = 'node';
+  $view->human_name = 'test_editable_views_node_properties';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Test editable views node properties';
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'some';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+  $handler->display->display_options['style_plugin'] = 'editableviews_table';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = '';
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  /* Field: Content: Entity metadata property (editable) */
+  $handler->display->display_options['fields']['metadata_property_editable']['id'] = 'metadata_property_editable';
+  $handler->display->display_options['fields']['metadata_property_editable']['table'] = 'node';
+  $handler->display->display_options['fields']['metadata_property_editable']['field'] = 'metadata_property_editable';
+  $handler->display->display_options['fields']['metadata_property_editable']['label'] = 'Status';
+  $handler->display->display_options['fields']['metadata_property_editable']['property'] = 'status';
+  /* Field: Content: Entity metadata property (editable) */
+  $handler->display->display_options['fields']['metadata_property_editable_1']['id'] = 'metadata_property_editable_1';
+  $handler->display->display_options['fields']['metadata_property_editable_1']['table'] = 'node';
+  $handler->display->display_options['fields']['metadata_property_editable_1']['field'] = 'metadata_property_editable';
+  $handler->display->display_options['fields']['metadata_property_editable_1']['label'] = 'Promote';
+  $handler->display->display_options['fields']['metadata_property_editable_1']['property'] = 'promote';
+  /* Field: Content: Entity metadata property (editable) */
+  $handler->display->display_options['fields']['metadata_property_editable_2']['id'] = 'metadata_property_editable_2';
+  $handler->display->display_options['fields']['metadata_property_editable_2']['table'] = 'node';
+  $handler->display->display_options['fields']['metadata_property_editable_2']['field'] = 'metadata_property_editable';
+  $handler->display->display_options['fields']['metadata_property_editable_2']['label'] = 'Sticky';
+  $handler->display->display_options['fields']['metadata_property_editable_2']['property'] = 'sticky';
+  /* Sort criterion: Content: Post date */
+  $handler->display->display_options['sorts']['created']['id'] = 'created';
+  $handler->display->display_options['sorts']['created']['table'] = 'node';
+  $handler->display->display_options['sorts']['created']['field'] = 'created';
+  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'editable_views_test_node' => 'editable_views_test_node',
+  );
+
+  /* Display: Page */
+  $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['path'] = 'test-editable-views-node-properties';
+  $export['test_editable_views_node_properties'] = $view;
+
+  $view = new view();
+  $view->name = 'test_editable_views_node_referenced_backwards_title';
+  $view->description = '';
+  $view->tag = 'default';
+  $view->base_table = 'node';
+  $view->human_name = 'Test editable views node referenced backwards title';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Test editable views node title';
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'some';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+  $handler->display->display_options['style_plugin'] = 'editableviews_table';
+  $handler->display->display_options['style_options']['columns'] = array(
+    'title_editable' => 'title_editable',
+    'title_editable_1' => 'title_editable_1',
+  );
+  $handler->display->display_options['style_options']['default'] = '-1';
+  $handler->display->display_options['style_options']['info'] = array(
+    'title_editable' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'title_editable_1' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+  );
+  $handler->display->display_options['style_options']['relationship_creation_bundle'] = array(
+    'reverse_field_test_node_reference_node' => 'editable_views_test_referencing',
+  );
+  /* Relationship: Entity Reference: Referencing entity */
+  $handler->display->display_options['relationships']['reverse_field_test_node_reference_node']['id'] = 'reverse_field_test_node_reference_node';
+  $handler->display->display_options['relationships']['reverse_field_test_node_reference_node']['table'] = 'node';
+  $handler->display->display_options['relationships']['reverse_field_test_node_reference_node']['field'] = 'reverse_field_test_node_reference_node';
+  /* Field: Content: Title (editable) */
+  $handler->display->display_options['fields']['title_editable']['id'] = 'title_editable';
+  $handler->display->display_options['fields']['title_editable']['table'] = 'node';
+  $handler->display->display_options['fields']['title_editable']['field'] = 'title_editable';
+  $handler->display->display_options['fields']['title_editable']['textfield_size'] = '';
+  /* Field: Content: Title (editable) */
+  $handler->display->display_options['fields']['title_editable_1']['id'] = 'title_editable_1';
+  $handler->display->display_options['fields']['title_editable_1']['table'] = 'node';
+  $handler->display->display_options['fields']['title_editable_1']['field'] = 'title_editable';
+  $handler->display->display_options['fields']['title_editable_1']['relationship'] = 'reverse_field_test_node_reference_node';
+  $handler->display->display_options['fields']['title_editable_1']['textfield_size'] = '';
+  /* Sort criterion: Content: Post date */
+  $handler->display->display_options['sorts']['created']['id'] = 'created';
+  $handler->display->display_options['sorts']['created']['table'] = 'node';
+  $handler->display->display_options['sorts']['created']['field'] = 'created';
+  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'editable_views_test_node' => 'editable_views_test_node',
+  );
+
+  /* Display: Page */
+  $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['path'] = 'test_editable_views_node_referenced_backwards_title';
+  $export['test_editable_views_node_referenced_backwards_title'] = $view;
+
+  $view = new view();
+  $view->name = 'test_editable_views_node_referenced_forwards_title';
+  $view->description = '';
+  $view->tag = 'default';
+  $view->base_table = 'node';
+  $view->human_name = 'Test editable views node referenced forwards title';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Test editable views node title';
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'some';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+  $handler->display->display_options['style_plugin'] = 'editableviews_table';
+  $handler->display->display_options['style_options']['columns'] = array(
+    'title_editable' => 'title_editable',
+    'title_editable_1' => 'title_editable_1',
+  );
+  $handler->display->display_options['style_options']['default'] = '-1';
+  $handler->display->display_options['style_options']['info'] = array(
+    'title_editable' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'title_editable_1' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+  );
+  $handler->display->display_options['style_options']['relationship_creation_bundle'] = array(
+    'field_test_node_reference_target_id' => 'editable_views_test_node',
+  );
+  /* Relationship: Entity Reference: Referenced Entity */
+  $handler->display->display_options['relationships']['field_test_node_reference_target_id']['id'] = 'field_test_node_reference_target_id';
+  $handler->display->display_options['relationships']['field_test_node_reference_target_id']['table'] = 'field_data_field_test_node_reference';
+  $handler->display->display_options['relationships']['field_test_node_reference_target_id']['field'] = 'field_test_node_reference_target_id';
+  /* Field: Content: Title (editable) */
+  $handler->display->display_options['fields']['title_editable']['id'] = 'title_editable';
+  $handler->display->display_options['fields']['title_editable']['table'] = 'node';
+  $handler->display->display_options['fields']['title_editable']['field'] = 'title_editable';
+  $handler->display->display_options['fields']['title_editable']['textfield_size'] = '';
+  /* Field: Content: Title (editable) */
+  $handler->display->display_options['fields']['title_editable_1']['id'] = 'title_editable_1';
+  $handler->display->display_options['fields']['title_editable_1']['table'] = 'node';
+  $handler->display->display_options['fields']['title_editable_1']['field'] = 'title_editable';
+  $handler->display->display_options['fields']['title_editable_1']['relationship'] = 'field_test_node_reference_target_id';
+  $handler->display->display_options['fields']['title_editable_1']['textfield_size'] = '';
+  /* Sort criterion: Content: Post date */
+  $handler->display->display_options['sorts']['created']['id'] = 'created';
+  $handler->display->display_options['sorts']['created']['table'] = 'node';
+  $handler->display->display_options['sorts']['created']['field'] = 'created';
+  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'editable_views_test_referencing' => 'editable_views_test_referencing',
+  );
+
+  /* Display: Page */
+  $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['path'] = 'test_editable_views_node_referenced_forwards_title';
+  $export['test_editable_views_node_referenced_forwards_title'] = $view;
+
+  $view = new view();
+  $view->name = 'test_editable_views_node_title';
+  $view->description = '';
+  $view->tag = 'default';
+  $view->base_table = 'node';
+  $view->human_name = 'Test editable views node title';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Test editable views node title';
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'some';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+  $handler->display->display_options['style_plugin'] = 'editableviews_table';
+  /* Field: Content: Title (editable) */
+  $handler->display->display_options['fields']['title_editable']['id'] = 'title_editable';
+  $handler->display->display_options['fields']['title_editable']['table'] = 'node';
+  $handler->display->display_options['fields']['title_editable']['field'] = 'title_editable';
+  $handler->display->display_options['fields']['title_editable']['textfield_size'] = '';
+  /* Sort criterion: Content: Post date */
+  $handler->display->display_options['sorts']['created']['id'] = 'created';
+  $handler->display->display_options['sorts']['created']['table'] = 'node';
+  $handler->display->display_options['sorts']['created']['field'] = 'created';
+  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'editable_views_test_node' => 'editable_views_test_node',
+  );
+
+  /* Display: Page */
+  $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['path'] = 'test-editable-views-node-title';
+  $export['test_editable_views_node_title'] = $view;
+
+  return $export;
+}

--- a/docroot/sites/all/modules/features/ilr_accessibility/ilr_accessibility.features.field_base.inc
+++ b/docroot/sites/all/modules/features/ilr_accessibility/ilr_accessibility.features.field_base.inc
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * ilr_accessibility.features.field_base.inc
+ */
+
+/**
+ * Implements hook_field_default_field_bases().
+ */
+function ilr_accessibility_field_default_field_bases() {
+  $field_bases = array();
+
+  // Exported field_base: 'field_accessibility_processed'.
+  $field_bases['field_accessibility_processed'] = array(
+    'active' => 1,
+    'cardinality' => 1,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'field_accessibility_processed',
+    'indexes' => array(
+      'value' => array(
+        0 => 'value',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'list',
+    'settings' => array(
+      'allowed_values' => array(
+        0 => '',
+        1 => '',
+      ),
+      'allowed_values_function' => '',
+    ),
+    'translatable' => 0,
+    'type' => 'list_boolean',
+  );
+
+  return $field_bases;
+}

--- a/docroot/sites/all/modules/features/ilr_accessibility/ilr_accessibility.features.field_instance.inc
+++ b/docroot/sites/all/modules/features/ilr_accessibility/ilr_accessibility.features.field_instance.inc
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @file
+ * ilr_accessibility.features.field_instance.inc
+ */
+
+/**
+ * Implements hook_field_default_field_instances().
+ */
+function ilr_accessibility_field_default_field_instances() {
+  $field_instances = array();
+
+  // Exported field_instance: 'file-image-field_accessibility_processed'.
+  $field_instances['file-image-field_accessibility_processed'] = array(
+    'bundle' => 'image',
+    'default_value' => array(
+      0 => array(
+        'value' => 0,
+      ),
+    ),
+    'deleted' => 0,
+    'description' => 'This is a temporary field, used to mark the progress of reviewing these images for accessibility.',
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 4,
+      ),
+      'preview' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'teaser' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'wysiwyg' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+    ),
+    'entity_type' => 'file',
+    'fences_wrapper' => 'div',
+    'field_name' => 'field_accessibility_processed',
+    'label' => 'Accessibility Processed',
+    'required' => 0,
+    'settings' => array(
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'active' => 1,
+      'module' => 'options',
+      'settings' => array(
+        'display_label' => 1,
+      ),
+      'type' => 'options_onoff',
+      'weight' => 33,
+    ),
+  );
+
+  // Translatables
+  // Included for use with string extractors like potx.
+  t('Accessibility Processed');
+  t('This is a temporary field, used to mark the progress of reviewing these images for accessibility.');
+
+  return $field_instances;
+}

--- a/docroot/sites/all/modules/features/ilr_accessibility/ilr_accessibility.features.inc
+++ b/docroot/sites/all/modules/features/ilr_accessibility/ilr_accessibility.features.inc
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * ilr_accessibility.features.inc
+ */
+
+/**
+ * Implements hook_views_api().
+ */
+function ilr_accessibility_views_api($module = NULL, $api = NULL) {
+  return array("api" => "3.0");
+}

--- a/docroot/sites/all/modules/features/ilr_accessibility/ilr_accessibility.info
+++ b/docroot/sites/all/modules/features/ilr_accessibility/ilr_accessibility.info
@@ -1,0 +1,16 @@
+name = ILR Accessibility
+description = Accessibility helpers, including an image file alt attribute bulk editor.
+core = 7.x
+package = ILR
+version = 7.x-1.0
+dependencies[] = editableviews
+dependencies[] = features
+dependencies[] = list
+dependencies[] = views
+features[ctools][] = views:views_default:3.0
+features[features_api][] = api:2
+features[field_base][] = field_accessibility_processed
+features[field_instance][] = file-image-field_accessibility_processed
+features[views_view][] = image_files_editable
+features_exclude[dependencies][ctools] = ctools
+features_exclude[dependencies][options] = options

--- a/docroot/sites/all/modules/features/ilr_accessibility/ilr_accessibility.module
+++ b/docroot/sites/all/modules/features/ilr_accessibility/ilr_accessibility.module
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Code for the ILR Accessibility feature.
+ */
+
+include_once 'ilr_accessibility.features.inc';

--- a/docroot/sites/all/modules/features/ilr_accessibility/ilr_accessibility.views_default.inc
+++ b/docroot/sites/all/modules/features/ilr_accessibility/ilr_accessibility.views_default.inc
@@ -1,0 +1,307 @@
+<?php
+
+/**
+ * @file
+ * ilr_accessibility.views_default.inc
+ */
+
+/**
+ * Implements hook_views_default_views().
+ */
+function ilr_accessibility_views_default_views() {
+  $export = array();
+
+  $view = new view();
+  $view->name = 'image_files_editable';
+  $view->description = '';
+  $view->tag = 'default';
+  $view->base_table = 'file_managed';
+  $view->human_name = 'Image Files Editable';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Image Files Editable';
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['access']['perm'] = 'administer files';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '20';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['pager']['options']['id'] = '0';
+  $handler->display->display_options['pager']['options']['quantity'] = '9';
+  $handler->display->display_options['style_plugin'] = 'editableviews_table';
+  $handler->display->display_options['style_options']['columns'] = array(
+    'rendered' => 'rendered',
+    'field_file_image_alt_text_editable' => 'field_file_image_alt_text_editable',
+    'field_file_image_title_text_editable' => 'field_file_image_title_text_editable',
+    'field_file_image_caption_editable' => 'field_file_image_caption_editable',
+    'filename' => 'filename',
+  );
+  $handler->display->display_options['style_options']['default'] = '-1';
+  $handler->display->display_options['style_options']['info'] = array(
+    'rendered' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_file_image_alt_text_editable' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_file_image_title_text_editable' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_file_image_caption_editable' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'filename' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+  );
+  $handler->display->display_options['style_options']['sticky'] = TRUE;
+  $handler->display->display_options['style_options']['save_messages'] = 'summary';
+  $handler->display->display_options['style_options']['batch_size'] = '10';
+  /* Header: Global: Result summary */
+  $handler->display->display_options['header']['result']['id'] = 'result';
+  $handler->display->display_options['header']['result']['table'] = 'views';
+  $handler->display->display_options['header']['result']['field'] = 'result';
+  /* Field: File: Rendered */
+  $handler->display->display_options['fields']['rendered']['id'] = 'rendered';
+  $handler->display->display_options['fields']['rendered']['table'] = 'file_managed';
+  $handler->display->display_options['fields']['rendered']['field'] = 'rendered';
+  $handler->display->display_options['fields']['rendered']['label'] = 'Thumbnail';
+  $handler->display->display_options['fields']['rendered']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['rendered']['file_view_mode'] = 'preview';
+  /* Field: File: Alt Text (editable) */
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['id'] = 'field_file_image_alt_text_editable';
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['table'] = 'field_data_field_file_image_alt_text';
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['field'] = 'field_file_image_alt_text_editable';
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['label'] = 'Alt Text';
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['element_type'] = '0';
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['element_wrapper_type'] = '0';
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['settings'] = array(
+    'field_formatter_label' => '',
+  );
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['field_api_classes'] = TRUE;
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['widget_type'] = '0';
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['suppress_label'] = 1;
+  $handler->display->display_options['fields']['field_file_image_alt_text_editable']['suppress_description'] = 1;
+  /* Field: File: Title Text (editable) */
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['id'] = 'field_file_image_title_text_editable';
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['table'] = 'field_data_field_file_image_title_text';
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['field'] = 'field_file_image_title_text_editable';
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['label'] = 'Title Text';
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['element_type'] = '0';
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['element_wrapper_type'] = '0';
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['settings'] = array(
+    'field_formatter_label' => '',
+  );
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['field_api_classes'] = TRUE;
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['widget_type'] = '0';
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['suppress_label'] = 1;
+  $handler->display->display_options['fields']['field_file_image_title_text_editable']['suppress_description'] = 1;
+  /* Field: File: Caption (editable) */
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['id'] = 'field_file_image_caption_editable';
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['table'] = 'field_data_field_file_image_caption';
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['field'] = 'field_file_image_caption_editable';
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['label'] = 'Caption';
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['element_type'] = '0';
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['element_wrapper_type'] = '0';
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['settings'] = array(
+    'field_formatter_label' => '',
+  );
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['field_api_classes'] = TRUE;
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['widget_type'] = '0';
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['suppress_label'] = 1;
+  $handler->display->display_options['fields']['field_file_image_caption_editable']['suppress_description'] = 1;
+  /* Field: Field: Tags (editable) */
+  $handler->display->display_options['fields']['field_tags_editable']['id'] = 'field_tags_editable';
+  $handler->display->display_options['fields']['field_tags_editable']['table'] = 'field_data_field_tags';
+  $handler->display->display_options['fields']['field_tags_editable']['field'] = 'field_tags_editable';
+  $handler->display->display_options['fields']['field_tags_editable']['label'] = 'Tags';
+  $handler->display->display_options['fields']['field_tags_editable']['element_type'] = '0';
+  $handler->display->display_options['fields']['field_tags_editable']['element_wrapper_type'] = '0';
+  $handler->display->display_options['fields']['field_tags_editable']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_tags_editable']['settings'] = array(
+    'field_formatter_label' => '',
+  );
+  $handler->display->display_options['fields']['field_tags_editable']['delta_offset'] = '0';
+  $handler->display->display_options['fields']['field_tags_editable']['field_api_classes'] = TRUE;
+  $handler->display->display_options['fields']['field_tags_editable']['widget_type'] = '0';
+  $handler->display->display_options['fields']['field_tags_editable']['suppress_label'] = 1;
+  $handler->display->display_options['fields']['field_tags_editable']['suppress_description'] = 1;
+  /* Field: File: Name */
+  $handler->display->display_options['fields']['filename']['id'] = 'filename';
+  $handler->display->display_options['fields']['filename']['table'] = 'file_managed';
+  $handler->display->display_options['fields']['filename']['field'] = 'filename';
+  $handler->display->display_options['fields']['filename']['label'] = 'Filename';
+  $handler->display->display_options['fields']['filename']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['filename']['alter']['ellipsis'] = FALSE;
+  /* Field: File: Accessibility Processed (editable) */
+  $handler->display->display_options['fields']['field_accessibility_processed_editable']['id'] = 'field_accessibility_processed_editable';
+  $handler->display->display_options['fields']['field_accessibility_processed_editable']['table'] = 'field_data_field_accessibility_processed';
+  $handler->display->display_options['fields']['field_accessibility_processed_editable']['field'] = 'field_accessibility_processed_editable';
+  $handler->display->display_options['fields']['field_accessibility_processed_editable']['label'] = 'Processed';
+  $handler->display->display_options['fields']['field_accessibility_processed_editable']['element_type'] = '0';
+  $handler->display->display_options['fields']['field_accessibility_processed_editable']['element_wrapper_type'] = '0';
+  $handler->display->display_options['fields']['field_accessibility_processed_editable']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_accessibility_processed_editable']['settings'] = array(
+    'field_formatter_label' => '',
+  );
+  $handler->display->display_options['fields']['field_accessibility_processed_editable']['field_api_classes'] = TRUE;
+  $handler->display->display_options['fields']['field_accessibility_processed_editable']['widget_type'] = '0';
+  $handler->display->display_options['fields']['field_accessibility_processed_editable']['suppress_label'] = 1;
+  $handler->display->display_options['fields']['field_accessibility_processed_editable']['suppress_description'] = 1;
+  /* Sort criterion: File: Upload date */
+  $handler->display->display_options['sorts']['timestamp']['id'] = 'timestamp';
+  $handler->display->display_options['sorts']['timestamp']['table'] = 'file_managed';
+  $handler->display->display_options['sorts']['timestamp']['field'] = 'timestamp';
+  $handler->display->display_options['sorts']['timestamp']['order'] = 'DESC';
+  /* Filter criterion: File: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'file_managed';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'image' => 'image',
+  );
+  /* Filter criterion: File: Accessibility Processed (field_accessibility_processed) */
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['id'] = 'field_accessibility_processed_value';
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['table'] = 'field_data_field_accessibility_processed';
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['field'] = 'field_accessibility_processed_value';
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['operator'] = 'empty';
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['value'] = array(
+    0 => '0',
+  );
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['expose']['operator_id'] = 'field_accessibility_processed_value_op';
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['expose']['label'] = 'Accessibility Processed';
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['expose']['use_operator'] = TRUE;
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['expose']['operator'] = 'field_accessibility_processed_value_op';
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['expose']['identifier'] = 'field_accessibility_processed_value';
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['expose']['multiple'] = TRUE;
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    11 => 0,
+    16 => 0,
+    41 => 0,
+    51 => 0,
+    46 => 0,
+    21 => 0,
+    26 => 0,
+    31 => 0,
+    56 => 0,
+    61 => 0,
+  );
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['is_grouped'] = TRUE;
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['group_info']['label'] = 'Accessibility Processed';
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['group_info']['identifier'] = 'field_accessibility_processed_value';
+  $handler->display->display_options['filters']['field_accessibility_processed_value']['group_info']['group_items'] = array(
+    1 => array(
+      'title' => 'Unprocessed',
+      'operator' => 'not',
+      'value' => array(
+        1 => '1',
+      ),
+    ),
+    2 => array(
+      'title' => 'Processed',
+      'operator' => 'or',
+      'value' => array(
+        1 => '1',
+      ),
+    ),
+  );
+  /* Filter criterion: File: Alt Text (field_file_image_alt_text) */
+  $handler->display->display_options['filters']['field_file_image_alt_text_value']['id'] = 'field_file_image_alt_text_value';
+  $handler->display->display_options['filters']['field_file_image_alt_text_value']['table'] = 'field_data_field_file_image_alt_text';
+  $handler->display->display_options['filters']['field_file_image_alt_text_value']['field'] = 'field_file_image_alt_text_value';
+  $handler->display->display_options['filters']['field_file_image_alt_text_value']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['field_file_image_alt_text_value']['expose']['operator_id'] = 'field_file_image_alt_text_value_op';
+  $handler->display->display_options['filters']['field_file_image_alt_text_value']['expose']['label'] = 'Alt Text (field_file_image_alt_text)';
+  $handler->display->display_options['filters']['field_file_image_alt_text_value']['expose']['operator'] = 'field_file_image_alt_text_value_op';
+  $handler->display->display_options['filters']['field_file_image_alt_text_value']['expose']['identifier'] = 'field_file_image_alt_text_value';
+  $handler->display->display_options['filters']['field_file_image_alt_text_value']['is_grouped'] = TRUE;
+  $handler->display->display_options['filters']['field_file_image_alt_text_value']['group_info']['label'] = 'Alt Text';
+  $handler->display->display_options['filters']['field_file_image_alt_text_value']['group_info']['identifier'] = 'field_file_image_alt_text_value';
+  $handler->display->display_options['filters']['field_file_image_alt_text_value']['group_info']['group_items'] = array(
+    1 => array(
+      'title' => 'Empty',
+      'operator' => 'empty',
+      'value' => '0',
+    ),
+    2 => array(
+      'title' => 'Not Empty',
+      'operator' => 'not empty',
+      'value' => '0',
+    ),
+  );
+  /* Filter criterion: File: Name */
+  $handler->display->display_options['filters']['filename']['id'] = 'filename';
+  $handler->display->display_options['filters']['filename']['table'] = 'file_managed';
+  $handler->display->display_options['filters']['filename']['field'] = 'filename';
+  $handler->display->display_options['filters']['filename']['operator'] = 'contains';
+  $handler->display->display_options['filters']['filename']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['filename']['expose']['operator_id'] = 'filename_op';
+  $handler->display->display_options['filters']['filename']['expose']['label'] = 'Name';
+  $handler->display->display_options['filters']['filename']['expose']['operator'] = 'filename_op';
+  $handler->display->display_options['filters']['filename']['expose']['identifier'] = 'filename';
+  $handler->display->display_options['filters']['filename']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    11 => 0,
+    16 => 0,
+    41 => 0,
+    51 => 0,
+    46 => 0,
+    21 => 0,
+    26 => 0,
+    31 => 0,
+    56 => 0,
+    61 => 0,
+  );
+  $handler->display->display_options['filters']['filename']['group_info']['label'] = 'Name';
+  $handler->display->display_options['filters']['filename']['group_info']['identifier'] = 'filename';
+  $handler->display->display_options['filters']['filename']['group_info']['remember'] = FALSE;
+  $handler->display->display_options['filters']['filename']['group_info']['group_items'] = array(
+    1 => array(),
+    2 => array(),
+    3 => array(),
+  );
+
+  /* Display: Page */
+  $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['path'] = 'admin/tmp/image-files-editable';
+  $export['image_files_editable'] = $view;
+
+  return $export;
+}


### PR DESCRIPTION
[Editable Views](https://www.drupal.org/project/editableviews) for the win!

![Screen Shot 2019-08-21 at 3 56 00 PM](https://user-images.githubusercontent.com/389525/63473971-36e39380-c42c-11e9-8e1a-03818ec225f7.png)

This PR adds the _Editable Views_ module and an _ILR Accessibility_ feature module that includes a new 'processed' field for `image` files and a new editable view.

To test, enable _ILR Accessibility_ and visit `/admin/tmp/image-files-editable` to start editing fields. There's a save button at the bottom of the page. In my testing, it appears to save all file entities whether they've been modified or not.

We should definitely take a database snapshot before running this on production.