### PR TITLE
WA updates including mega menu and search updates

### DIFF
--- a/docroot/profiles/ilr/ilr.profile
+++ b/docroot/profiles/ilr/ilr.profile
@@ -199,7 +199,7 @@ function ilr_block_info() {
  */
 function ilr_block_view($delta='') {
   if ($delta == 'ilr_wordmark') {
-    $markup = '<div class="ilr-logo ilr-logo--wordmark"><a class="ilr-logo__link" href="/"><img src="/sites/all/themes/ilr_theme/images/logos/ILR-wordmark.svg"></a></div>';
+    $markup = '<div class="ilr-logo ilr-logo--wordmark"><a class="ilr-logo__link" href="/" ><img src="/sites/all/themes/ilr_theme/images/logos/ILR-wordmark.svg" alt="ILR School"></a></div>';
 
     $block = array(
       'subject' => '',

--- a/docroot/sites/all/modules/features/ilr_sdc_listings/ilr_sdc_listings.module
+++ b/docroot/sites/all/modules/features/ilr_sdc_listings/ilr_sdc_listings.module
@@ -580,6 +580,7 @@ function ilr_sdc_listings_search_form($form, &$form_state) {
     //'#size' => 20,
     '#attributes' => array(
       'placeholder' => 'Search ILR offerings',
+      'aria-label' => 'Search ILR offerings'
     ),
     '#default_value' => isset($_REQUEST['s']) ? $_REQUEST['s'] : '',
     '#autocomplete_path' => 'programs/professional-programs/courses/autocomplete',
@@ -1410,7 +1411,7 @@ function _ilr_sdc_listings_format_class_date_and_time($class) {
   $markup = '<div class="date-time contextual-links-region">';
   $markup .= _ilr_sdc_listings_get_contextual_link_markup($class);
   $datespan_class = ($wrapper->field_cancelled->value() == 1) ? 'date cancelled' : 'date';
-  $markup .= '<span class="'.$datespan_class.'">';
+  $markup .= '<span '.$datespan_class.'">';
   $markup .= _ilr_sdc_listings_get_class_datespan($class);
   $markup .= '</span>';
   $markup .= '<span class="time">';
@@ -1494,7 +1495,7 @@ function _ilr_sdc_listings_generate_class_button_markup($class_node, $include_pr
 }
 
 function _ilr_sdc_listings_generate_class_radio_label($class) {
-  $markup = '<div class="radio-label contextual-links-region">';
+  $markup = '<div class="radio-label contextual-links-region" id="course-' . $class->nid . '">';
   $markup .= _ilr_sdc_listings_get_contextual_link_markup($class);
   if (_ilr_sdc_listings_is_series($class)) {
     $markup .= '<span class="class-title">'.$class->title.'</span>';
@@ -2300,7 +2301,7 @@ function _ilr_sdc_listings_add_radio_markup(&$form, $classes) {
         $form[$class_id] = array(
           '#type' => 'radio',
           '#return_value' => $class_id,
-          '#attributes' => array('name' => 'addClass'),
+          '#attributes' => array('name' => 'addClass', 'aria-labelledby' => 'course-' . $nid),
           // Ensure single value in $form_state
           '#parents' => array('addClass'),
         );

--- a/docroot/sites/all/themes/ilr_theme/ilr_theme.info
+++ b/docroot/sites/all/themes/ilr_theme/ilr_theme.info
@@ -8,6 +8,8 @@ stylesheets[print][] = css/print.css
 
 scripts[] = js/ilr_theme.js
 scripts[] = js/union.js
+scripts[] = js/wa.js
+
 
 regions[header] = Header
 regions[highlighted] = Highlighted

--- a/docroot/sites/all/themes/ilr_theme/js/ilr_theme.js
+++ b/docroot/sites/all/themes/ilr_theme/js/ilr_theme.js
@@ -33,7 +33,7 @@
   };
   Drupal.behaviors.ilr_theme_search = {
     attach: function (context, settings) {
-      $('.search-button a').click(function(e){
+      $('.search-button button').click(function(e){
         e.preventDefault();
         $('header').toggleClass('search-engaged');
         $('#search-form-query').focus();

--- a/docroot/sites/all/themes/ilr_theme/js/wa.js
+++ b/docroot/sites/all/themes/ilr_theme/js/wa.js
@@ -8,7 +8,7 @@
       // Adding expander buttons after every top level nav item
       $(menuItems).each(function(e){
         $(this).attr("aria-expanded","false");
-        $(this).children('a').after("<button class='menuExpand' aria-expanded='false' tabindex='0' value='Expand Menu'><span aria-label='Expand " + $(this).children('a').text() + "' class='fas fa-caret-down'></span></button>");
+        $(this).children('a').after("<button class='menuExpand' aria-expanded='false' tabindex='0' value='Expand Menu' aria-label='Expand " + $(this).children('a').text()"><span aria-hidden='true' class='fas fa-caret-down'></span></button>");
       });
 
       $('.menuExpand').on('touchstart click', function (e){
@@ -57,10 +57,6 @@
       $('.closeSearch').click(function(){
         $('header').toggleClass('search-engaged');
       });
-
-      // $('.searchBtn').on('click', function(){
-      //   $('header').addClass('search-engaged');
-      // });
   }
 }
 

--- a/docroot/sites/all/themes/ilr_theme/js/wa.js
+++ b/docroot/sites/all/themes/ilr_theme/js/wa.js
@@ -8,7 +8,7 @@
       // Adding expander buttons after every top level nav item
       $(menuItems).each(function(e){
         $(this).attr("aria-expanded","false");
-        $(this).children('a').after("<button class='menuExpand' aria-expanded='false' tabindex='0' value='Expand Menu' aria-label='Expand " + $(this).children('a').text()"><span aria-hidden='true' class='fas fa-caret-down'></span></button>");
+        $(this).children('a').after("<button class='menuExpand' aria-expanded='false' tabindex='0' value='Expand Menu' aria-label='Expand " + $(this).children('a').text() + "'><span aria-hidden='true' class='fas fa-caret-down'></span></button>");
       });
 
       $('.menuExpand').on('touchstart click', function (e){

--- a/docroot/sites/all/themes/ilr_theme/js/wa.js
+++ b/docroot/sites/all/themes/ilr_theme/js/wa.js
@@ -1,0 +1,67 @@
+(function ($) {
+   //Add icons to menu for dropdown on focus
+  Drupal.behaviors.wa_menu = {
+    attach: function (context, settings) {
+      var menuItems = ".menu li.menu-item";
+      var menuLinks = ".menu-view-wrapper";
+
+      // Adding expander buttons after every top level nav item
+      $(menuItems).each(function(e){
+        $(this).attr("aria-expanded","false");
+        $(this).children('a').after("<button class='menuExpand' aria-expanded='false' tabindex='0' value='Expand Menu'><span aria-label='Expand " + $(this).children('a').text() + "' class='fas fa-caret-down'></span></button>");
+      });
+
+      $('.menuExpand').on('touchstart click', function (e){
+
+        var submenu = $(this).next('.submenu');
+
+        $(this).toggleClass('expanded');
+
+        if($(this).hasClass('expanded')) {
+          $(this).attr('aria-expanded','true');
+        }
+        else {
+          $(this).attr('aria-expanded','false');
+        }
+
+        $('.menu-block-ilr-primary-menu').addClass('active');
+        $(submenu).toggleClass('active');
+
+        if((submenu).hasClass('active')) {
+          $(submenu).css("opacity","1");
+        }
+        else {
+          $(submenu).css("opacity","0");
+        }
+      });
+
+      // Able to close menu by hitting escape
+      $(document).on('keydown', function(event) {
+
+        if (event.key === "Escape") {
+          // Find element that was active when escape was hit
+          var active = $(document.activeElement);
+
+          // Shift focus to the button for that element group
+          active.parents().siblings('.menuExpand').focus();
+
+          // Take off all active menu features
+          $(menuItems).each(function(e){
+            $(this).find('.menuExpand').attr("aria-expanded","false")
+            $(this).find('.submenu').removeClass("active").css("opacity","0");;
+            $('.menu-block-ilr-primary-menu').removeClass("active");
+          });
+        }
+      });
+
+      $('.closeSearch').click(function(){
+        $('header').toggleClass('search-engaged');
+      });
+
+      // $('.searchBtn').on('click', function(){
+      //   $('header').addClass('search-engaged');
+      // });
+  }
+}
+
+}(jQuery));

--- a/docroot/sites/all/themes/ilr_theme/scss/base/_typography.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/base/_typography.scss
@@ -228,12 +228,14 @@ a, a:visited {
 a:hover, a:focus {
   color: $link-hover;
   text-decoration: none;
+  border-bottom: none;
 }
 
 // Underlines? @todo - figure out what to do here
 p a, p a:visited,
 li a {
   @include set-link($cornell-red);
+  border-bottom: 1px dotted;
 
   &[href^="mailto:"] {
     border: none;

--- a/docroot/sites/all/themes/ilr_theme/scss/base/_variables.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/base/_variables.scss
@@ -128,7 +128,7 @@ $p-size: ms(0);
 $p-sm-size: $mod-01;
 
 $link: lighten($brand, 10%);
-$link-hover: lighten($brand, 20%);
+$link-hover: #e12e1b;
 $nav-color: #2D4063;
 $nav-size: 1.2em;
 

--- a/docroot/sites/all/themes/ilr_theme/scss/components/_breadcrumbs.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_breadcrumbs.scss
@@ -1,7 +1,7 @@
 #breadcrumb {
   .breadcrumb {
     @include adjust-font-size-to(14px);
-
+    color: #181818;
     span {
       padding: 0;
       color: $link;
@@ -9,6 +9,11 @@
 
     a {
       text-decoration: none;
+
+      &:after {
+        content: " /";
+        color: black;
+      }
     }
   }
   // Hide breadcrumbs on mobile version

--- a/docroot/sites/all/themes/ilr_theme/scss/components/_courses_and_classes.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_courses_and_classes.scss
@@ -246,6 +246,10 @@ form.class-details {
     .social-share {
       @include trailer(1);
       text-align: left;
+
+      a {
+        border-bottom: none;
+      }
     }
 
     .field-name-body {

--- a/docroot/sites/all/themes/ilr_theme/scss/components/_footer.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_footer.scss
@@ -8,7 +8,8 @@ footer {
 
   a, a:visited {
     color: $black;
-    border-bottom: none;
+    border-bottom: 1px solid transparent;
+
     &:hover {
       color: lighten($black, 10%);
       border-bottom: 1px solid lighten($black, 10%);

--- a/docroot/sites/all/themes/ilr_theme/scss/components/_header.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_header.scss
@@ -73,6 +73,9 @@ header {
 
   .buttons {
     order: 3;
+     [data-menu-position="open"] & {
+      min-width: 5rem;
+     }
   }
 }
 
@@ -90,11 +93,16 @@ header {
 }
 
 %header-btn {
-  @include transition-duration(.3s);
+  // @include transition-duration(.3s);
   position: absolute;
   top: 1rem;
-  right: 0;
+  right: 0rem;
   z-index: 10;
+
+  [data-menu-position="open"] & {
+    position: fixed;
+    right: 1rem;
+  }
 
   [data-eq-state="regular-nav"]:not(.sticky) & {
     body:not(.subsite) & {
@@ -102,9 +110,9 @@ header {
     }
   }
 
-  @include medium {
-    right: 2rem;
-  }
+  // @include medium {
+  //   right: 2rem;
+  // }
 
   a {
     display: block;

--- a/docroot/sites/all/themes/ilr_theme/scss/components/_mega_menu.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_mega_menu.scss
@@ -80,7 +80,7 @@
 
         div.submenu {
           white-space: normal;
-          text-indent: -1em;
+          margin-left: -1em;
           margin-top:30px;
         }
       }
@@ -152,15 +152,18 @@
     .field-name-field-referenced-entity {
       @include three-column;
 
-      article h2 {
-        @include adjust-font-size-to(17px);
+      .content {
 
-        font-weight: normal;
-        margin: 0;
+        div {
 
-        a {
-          color: $black;
-          border-bottom: none;
+          a {
+            margin: 0;
+            font-weight: 400;
+            color: $black;
+            border-bottom: none;
+
+            @include adjust-font-size-to(17px);
+          }
         }
       }
     }

--- a/docroot/sites/all/themes/ilr_theme/scss/components/_mega_menu.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_mega_menu.scss
@@ -22,7 +22,25 @@
         list-style: none;
         line-height: 1;
         margin: 0;
-        padding: 0;
+        padding: 5px;
+
+        .menuExpand {
+          background: none;
+          border: none;
+          position: relative;
+          float: left;
+          top: 2px;
+          padding: 0px 5px 0px 2px;
+          left: -2px;
+          z-index: -1;
+        
+          &:focus {
+            z-index: 11;
+            outline: 1px dotted $cornell-red
+          }
+        }
+
+
 
         > a, > a:visited {
           flex-grow: 1;
@@ -35,10 +53,12 @@
           font-weight: 400;
           font-size: 15px;
           outline: 0;
-          padding: 1.2rem;
-          display: block;
-          width: 100%;
+          padding: .3rem .4rem;
+          display: inline-block;
+          // width: 100%;
           text-align: center;
+          position: relative;
+          float: left;
 
           .sticky & {
             padding-top: .75em;
@@ -47,6 +67,10 @@
 
           &:hover {
             color: $cornell-red;
+          }
+          &:focus {
+            outline: 1px dotted $cornell-red
+
           }
         }
 
@@ -57,6 +81,7 @@
         div.submenu {
           white-space: normal;
           text-indent: -1em;
+          margin-top:30px;
         }
       }
     }

--- a/docroot/sites/all/themes/ilr_theme/scss/components/_search.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_search.scss
@@ -1,7 +1,17 @@
 .search-button {
   position: relative;
-  a {
-    @include transition-duration(.3s);
+  [data-menu-position="open"] & {
+    min-height: 38px;
+    min-width: 45px;
+    text-align: center;
+    top: 1rem;
+    position: fixed;
+    z-index: 11;
+  }
+  button {
+    // @include transition-duration(.3s);
+    border: 0px;
+    background: none;
     @extend %icon-search-thin;
 
     visibility: hidden;
@@ -11,10 +21,9 @@
     [data-menu-position="open"] & {
       color: white;
       visibility: visible;
-      position: absolute;
+      position: relative;
       z-index: 10;
-      right: .9em;
-      top: -2.5rem;
+      padding: 10px 13px 5px 13px;
     }
 
     .subsite & {
@@ -43,6 +52,12 @@
   position: absolute;
   top: 0;
 
+  .closeSearch {
+    color: $white;
+    border: none;
+    background: transparent;
+  }
+
   .search-engaged & {
     height: auto;
   }
@@ -54,7 +69,7 @@
   input {
     @include rhythm(1);
     border: none;
-    width: 100%;
+    width: 90%;
     padding: 0 0 0 15px;
     background: $black;
     border-left: 5px solid $cornell-red;

--- a/docroot/sites/all/themes/ilr_theme/scss/components/_skip-link.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_skip-link.scss
@@ -1,0 +1,19 @@
+.skip-link {
+  margin:25px;
+  border: 1px solid;
+  padding:10px;
+  position: absolute;
+  left: -9999px;
+  top: -9999px;
+
+  &:focus, &:hover {
+    color: white;
+    background: $link;
+  }
+
+  &:focus {
+    display: inline;
+    left: 0px;
+    top: 0px;
+  }
+}

--- a/docroot/sites/all/themes/ilr_theme/scss/components/_union.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_union.scss
@@ -15,7 +15,7 @@
   }
 }
 
-.cu-card--promo.cu-card--landscape {
+body.not-front .cu-card--promo.cu-card--landscape {
   .cu-card__content {
     .cu-card__fact-list {
       display: block;

--- a/docroot/sites/all/themes/ilr_theme/scss/components/_union.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/components/_union.scss
@@ -14,3 +14,16 @@
     content: '';
   }
 }
+
+.cu-card--promo.cu-card--landscape {
+  .cu-card__content {
+    .cu-card__fact-list {
+      display: block;
+    }
+    .cu-card__fact {
+      border-bottom: 2px solid rgba($white, 0.2);
+      border-right: none;
+      padding: var(--cu-vr0);
+    }
+  }
+}

--- a/docroot/sites/all/themes/ilr_theme/scss/style.scss
+++ b/docroot/sites/all/themes/ilr_theme/scss/style.scss
@@ -111,6 +111,7 @@ $base-line-height: 27px;
 @import "components/schedule.scss";
 @import "components/search.scss";
 @import "components/sidebar_second.scss";
+@import "components/skip-link.scss";
 @import "components/slc-banner.scss";
 @import "components/social.scss";
 @import "components/social_callout.scss";

--- a/docroot/sites/all/themes/ilr_theme/template.php
+++ b/docroot/sites/all/themes/ilr_theme/template.php
@@ -49,7 +49,7 @@ function ilr_theme_preprocess_page(&$variables) {
   $variables['page']['nav_trigger_pts'] =  array('#markup' => 'data-eq-pts="mobile-nav: 300, regular-nav: 1045"');
 
   if (!isset($variables['logo_link'])) {
-    $variables['logo_link'] = '<a class="cornell" title="Visit Cornell.edu" href="https://cornell.edu"></a>';
+    $variables['logo_link'] = '<a class="cornell" title="Visit Cornell.edu" alt="Cornell University" href="https://cornell.edu">Cornell University</a>';
   }
 
   if ( isset($_GET['layout']) && $_GET['layout'] == '0' ) {

--- a/docroot/sites/all/themes/ilr_theme/template.php
+++ b/docroot/sites/all/themes/ilr_theme/template.php
@@ -22,6 +22,8 @@ function ilr_theme_preprocess_html(&$variables) {
   drupal_add_js($gsap_path . '/TimelineLite.min.js', array('type' => 'file', 'scope' => 'footer'));
   drupal_add_js($gsap_path . '/easing/EasePack.min.js', array('type' => 'file', 'scope' => 'footer'));
   drupal_add_js($gsap_path . '/plugins/CSSPlugin.min.js', array('type' => 'file', 'scope' => 'footer'));
+  drupal_add_css('https://use.fontawesome.com/releases/v5.8.1/css/all.css', 'external');
+
   $isotope_js = libraries_get_path('isotope') . '/isotope.pkgd.min.js';
   drupal_add_js($isotope_js, array('type' => 'file', 'scope' => 'footer'));
   $hoverintent_js = libraries_get_path('hoverintent') . '/jquery.hoverIntent.minified.js';
@@ -189,7 +191,7 @@ function ilr_theme_breadcrumb($variables) {
     if (module_exists('ilr_sub_sites') && _ilr_sub_sites_get_menu_name() != 'main-menu') {
       $home_link = array_shift($breadcrumb); // Remove the home link
     }
-    return '<div class="breadcrumb">' . implode('<span> / </span>', $breadcrumb) . '</div>';
+    return '<nav class="breadcrumb">' . implode(' ', $breadcrumb) . '</nav>';
   }
 }
 

--- a/docroot/sites/all/themes/ilr_theme/templates/node--basic-page--mega-menu-item.tpl.php
+++ b/docroot/sites/all/themes/ilr_theme/templates/node--basic-page--mega-menu-item.tpl.php
@@ -1,0 +1,14 @@
+<div id="node-<?php print $node->nid; ?>" class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+
+  <?php print render($title_prefix); ?>
+  <?php if (!$page && $title): ?>
+      <?php if (empty($remove_title_link)): ?>
+        <a href="<?php print $node_url; ?>" class="mega-menu-sublinks">
+      <?php endif; ?>
+      <?php print $title; ?>
+      <?php if (empty($remove_title_link)): ?>
+        </a>
+      <?php endif; ?>
+  <?php endif; ?>
+
+</div>

--- a/docroot/sites/all/themes/ilr_theme/templates/node--channel-page--mega-menu-item.tpl.php
+++ b/docroot/sites/all/themes/ilr_theme/templates/node--channel-page--mega-menu-item.tpl.php
@@ -1,0 +1,14 @@
+<div id="node-<?php print $node->nid; ?>" class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+
+  <?php print render($title_prefix); ?>
+  <?php if (!$page && $title): ?>
+      <?php if (empty($remove_title_link)): ?>
+        <a href="<?php print $node_url; ?>" class="mega-menu-sublinks">
+      <?php endif; ?>
+      <?php print $title; ?>
+      <?php if (empty($remove_title_link)): ?>
+        </a>
+      <?php endif; ?>
+  <?php endif; ?>
+
+</div>

--- a/docroot/sites/all/themes/ilr_theme/templates/page.tpl.php
+++ b/docroot/sites/all/themes/ilr_theme/templates/page.tpl.php
@@ -1,7 +1,11 @@
 <header role="banner" <?php print render($page['nav_trigger_pts']); ?>>
+  <a class="skip-link" href="#main" tabindex="1">Skip to content</a>
   <div id="search-form">
     <form action="/search" method="get" id="cu-search-form" accept-charset="UTF-8">
-      <input id="search-form-query" type="text" name="s" placeholder="Search" value="" size="20" maxlength="128" class="form-text" />
+      <label class="sr-only" for="search-form-query">Search</label>
+      <input id="search-form-query" type="text" name="s" placeholder="Search" value="" size="20" maxlength="128" class="form-text" tabindex="-1" />
+      <button type="button" class="closeSearch fas fa-times"><span class="sr-only">Close Search</span></button>
+
     </form>
   </div>
   <div id="header-region">
@@ -16,16 +20,16 @@
       </a>
     </div>
     <?php endif; ?>
+    <div class="region-header__wrapper">
+      <?php print render($page['header']); ?>
+    </div>
     <div class='buttons'>
       <div class="jpanel-trigger-container">
         <a href="#" class="jpanel-trigger"></a>
       </div>
       <div class="search-button">
-        <a href="#"></a>
+        <button href="#" class="searchBtn fas fa-search"><span class="sr-only">Toggle Search</span></button>
       </div>
-    </div>
-    <div class="region-header__wrapper">
-      <?php print render($page['header']); ?>
     </div>
   </div>
   </div>
@@ -45,7 +49,7 @@
         <?php elseif ($title): ?><h1 class="title" id="page-title"><?php print $title; ?></h1><?php endif; ?>
         <?php print render($title_suffix); ?>
         <?php if ($breadcrumb): ?>
-        <div id="breadcrumb"><?php print $breadcrumb; ?></div>
+        <nav id="breadcrumb" aria-label="breadcrumb"><?php print $breadcrumb; ?></nav>
         <?php endif; ?>
         <?php print $messages; ?>
         <div class="section">

--- a/docroot/sites/all/themes/ilr_theme/templates/page.tpl.php
+++ b/docroot/sites/all/themes/ilr_theme/templates/page.tpl.php
@@ -13,8 +13,8 @@
     <?php if (isset($logo_override)): ?>
       <?php print $logo_override['#markup']; ?>
     <?php else: ?>
-    <div class="logo-wrapper">
-      <?php print $logo_link ?>
+    <div class="logo-wrapper"> 
+      <!-- <?php print $logo_link ?> -->
       <a class="ilr" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>" rel="home" id="logo">
          <img src="<?php echo $logo?>" alt="Cornell University | ILR School" title="Cornell University | ILR School">
       </a>
@@ -24,11 +24,11 @@
       <?php print render($page['header']); ?>
     </div>
     <div class='buttons'>
-      <div class="jpanel-trigger-container">
-        <a href="#" class="jpanel-trigger"></a>
+       <div class="jpanel-trigger-container">
+        <a class="jpanel-trigger"></a>
       </div>
       <div class="search-button">
-        <button href="#" class="searchBtn fas fa-search"><span class="sr-only">Toggle Search</span></button>
+        <button class="searchBtn fas fa-search"><span class="sr-only">Toggle Searchers</span></button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Among changes:

Search Input: 
Added a screen reader only label to identify it as search

Breadcrumb:
Updated the breadcrumb code in template.php to remove the <span> / </span>, instead putting the / in the CSS so that it isn’t read by a screen reader. Then I changed the color of the non-link text to #181818 which makes it 3:1 with the link color, and thus not needing to have an underline for the link color. 

Skiplink
Added a skip link

Mega Menu:
There was no keyboard navigation for the mega menu. So I added in dropdown buttons to allow keyboard users to navigate to mega menu.

Search Icon:
Moved search icon to be after mega menu buttons in the DOM order
Fixed search icon placement in mobile

Search
Added ability to close search without just using keyboard